### PR TITLE
Return `io::Error` types instead of unit.

### DIFF
--- a/platform/inprocess/mod.rs
+++ b/platform/inprocess/mod.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex, Condvar};
 use std::collections::hash_map::HashMap;
 use std::cell::{RefCell};
+use std::io::{Error, ErrorKind};
 use std::slice;
 use std::fmt::{self, Debug, Formatter};
 use std::cmp::{PartialEq};
@@ -345,5 +346,16 @@ impl MpscSharedMemory {
 pub enum MpscError {
     ChannelClosedError,
     UnknownError,
+}
+
+impl From<MpscError> for Error {
+    fn from(mpsc_error: MpscError) -> Error {
+        match mpsc_error {
+            MpscError::ChannelClosedError => {
+                Error::new(ErrorKind::BrokenPipe, "MPSC channel closed")
+            }
+            MpscError::UnknownError => Error::new(ErrorKind::Other, "Other MPSC channel error"),
+        }
+    }
 }
 

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -589,6 +589,12 @@ impl UnixError {
     }
 }
 
+impl From<UnixError> for Error {
+    fn from(unix_error: UnixError) -> Error {
+        Error::from_raw_os_error(unix_error.0)
+    }
+}
+
 #[derive(Copy, Clone)]
 enum BlockingMode {
     Blocking,


### PR DESCRIPTION
Should help diagnose intermittent Servo test failures.

r? @larsbergstrom 