### PR TITLE
Switch android to use the in-process ipc bypass.

### DIFF
--- a/platform/mod.rs
+++ b/platform/mod.rs
@@ -7,23 +7,23 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::channel;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixReceiver as OsIpcReceiver;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixSender as OsIpcSender;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixReceiverSet as OsIpcReceiverSet;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixSharedMemory as OsIpcSharedMemory;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixChannel as OsIpcChannel;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixSelectionResult as OsIpcSelectionResult;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::OpaqueUnixChannel as OsOpaqueIpcChannel;
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 pub use platform::linux::UnixOneShotServer as OsIpcOneShotServer;
 
 #[cfg(target_os="macos")]
@@ -45,31 +45,31 @@ pub use platform::macos::OpaqueMachChannel as OsOpaqueIpcChannel;
 #[cfg(target_os="macos")]
 pub use platform::macos::MachOneShotServer as OsIpcOneShotServer;
 
-// Windows uses in-process mpsc channels IPC for now
-#[cfg(target_os="windows")]
+// Windows and Android use in-process mpsc channels IPC for now
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::channel;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscReceiver as OsIpcReceiver;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscSender as OsIpcSender;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscReceiverSet as OsIpcReceiverSet;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscSharedMemory as OsIpcSharedMemory;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscChannel as OsIpcChannel;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscSelectionResult as OsIpcSelectionResult;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::OpaqueMpscChannel as OsOpaqueIpcChannel;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 pub use platform::inprocess::MpscOneShotServer as OsIpcOneShotServer;
 
-#[cfg(any(target_os="linux", target_os="android"))]
+#[cfg(target_os="linux")]
 mod linux;
 #[cfg(target_os="macos")]
 mod macos;
-#[cfg(target_os="windows")]
+#[cfg(any(target_os="windows", target_os="android"))]
 mod inprocess;
 
 #[cfg(test)]


### PR DESCRIPTION
This is a temporary workaround for some performance issues, and some android specific IPC crashes.