### PR TITLE
Derive Debug on some of the public types

### DIFF
--- a/ipc.rs
+++ b/ipc.rs
@@ -50,6 +50,7 @@ pub fn channel<T>() -> Result<(IpcSender<T>, IpcReceiver<T>),Error>
     Ok((ipc_sender, ipc_receiver))
 }
 
+#[derive(Debug)]
 pub struct IpcReceiver<T> where T: Deserialize + Serialize {
     os_receiver: OsIpcReceiver,
     phantom: PhantomData<T>,
@@ -103,6 +104,7 @@ impl<T> Serialize for IpcReceiver<T> where T: Deserialize + Serialize {
     }
 }
 
+#[derive(Debug)]
 pub struct IpcSender<T> where T: Serialize {
     os_sender: OsIpcSender,
     phantom: PhantomData<T>,
@@ -354,7 +356,7 @@ impl OpaqueIpcMessage {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct OpaqueIpcSender {
     os_sender: OsIpcSender,
 }
@@ -383,6 +385,7 @@ impl Serialize for OpaqueIpcSender {
     }
 }
 
+#[derive(Debug)]
 pub struct OpaqueIpcReceiver {
     os_receiver: OsIpcReceiver,
 }


### PR DESCRIPTION
Some of the types already have had working Debug implementations (or
derives) available in all the OS-specific backends; but for some reason
they were not exposed on the (portable) API types... Let's change that.

Note that this doesn't cover all of the public types -- some would
actually need Debug implementations to be newly introduced for all the
OS-specific backends, which would be much more involved than just
exposing the existing ones...

This is not tested on MacOS; however, the backends seem to be very symmetric -- so hopefully it should just work...