### PR TITLE
Fix: Provide dummy Debug impls for platform::inprocess::{MpscSender, …

### DIFF
--- a/platform/inprocess/mod.rs
+++ b/platform/inprocess/mod.rs
@@ -60,6 +60,14 @@ pub struct MpscReceiver {
     receiver: RefCell<Option<mpsc::Receiver<MpscChannelMessage>>>,
 }
 
+// Can't derive, as mpsc::Receiver doesn't implement Debug.
+impl fmt::Debug for MpscReceiver {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Not sure there is anything useful we could print here.
+        write!(f, "MpscReceiver {{ .. }}")
+    }
+}
+
 impl MpscReceiver {
     fn new(receiver: mpsc::Receiver<MpscChannelMessage>) -> MpscReceiver {
         MpscReceiver {
@@ -99,6 +107,14 @@ unsafe impl Sync for MpscReceiver { }
 #[derive(Clone)]
 pub struct MpscSender {
     sender: RefCell<mpsc::Sender<MpscChannelMessage>>,
+}
+
+// Can't derive, as mpsc::Sender doesn't implement Debug.
+impl fmt::Debug for MpscSender {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Not sure there is anything useful we could print here.
+        write!(f, "MpscSender {{ .. }}")
+    }
 }
 
 unsafe impl Send for MpscSender { }


### PR DESCRIPTION
…MpscReceiver}

Fixes a regression introduced by
410a6140fd75c070cad541611686c8e30c3965c3 (
https://github.com/servo/ipc-channel/pull/21 ), which broke compilation
for targets using the inprocess backend.