### PR TITLE
Linux: Fix corruption of big transfers on 32 bit systems

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -201,7 +201,7 @@ impl UnixSender {
                           &mut maximum_send_size_len as *mut socklen_t) < 0 {
                 return Err(UnixError::last())
             }
-            let bytes_per_fragment = maximum_send_size - (mem::size_of::<usize>() +
+            let bytes_per_fragment = maximum_send_size - (mem::size_of::<u32>() * 2 +
                 CMSG_SPACE(cmsg_length as size_t) as usize + 256);
 
             // Split up the packet into fragments.


### PR DESCRIPTION
The wrong size calculation magically worked on 64 bit systems, because
2 * sizeof u32 is the same as sizeof usize there -- but not on 32 bit
systems, where this dropped 4 bytes of each full fragment.

With this, Servo works again for me. (And we are down to 4 failing ipc-channel tests on my system...)