### PR TITLE
Linux: Don't pass uninitialised memory as pointers to libc::connect()

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -474,9 +474,9 @@ impl UnixOneShotServer {
                                    Vec<OpaqueUnixChannel>,
                                    Vec<UnixSharedMemory>),UnixError> {
         unsafe {
-            let mut sockaddr = mem::uninitialized();
-            let mut sockaddr_len = mem::uninitialized();
-            let client_fd = libc::accept(self.fd, &mut sockaddr, &mut sockaddr_len);
+            let sockaddr: *mut sockaddr = ptr::null_mut();
+            let sockaddr_len: *mut socklen_t = ptr::null_mut();
+            let client_fd = libc::accept(self.fd, sockaddr, sockaddr_len);
             if client_fd < 0 {
                 return Err(UnixError::last())
             }


### PR DESCRIPTION
I don't know whether there are constellations where taking a reference
to a binding containing mem::uninitialized() actually creates a proper
NULL pointer -- but it certainly doesn't on my system when using the
rustc snapshot from Servo.

Either way, creating explicit NULL pointers seems way more correct.

This fixes the other four testsuite failures, as well as servo -M