### PR TITLE
Fix concurrent large transfers by using dedicated channel

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -125,7 +125,7 @@ impl UnixSender {
 
     pub fn send(&self,
                 data: &[u8],
-                channels: Vec<UnixChannel>,
+                mut channels: Vec<UnixChannel>,
                 shared_memory_regions: Vec<UnixSharedMemory>)
                 -> Result<(),UnixError> {
         let mut data_buffer = vec![0; data.len() + mem::size_of::<u32>() * 2];
@@ -137,57 +137,68 @@ impl UnixSender {
         }
 
         unsafe {
-            let cmsg_length =
-                (channels.len() + shared_memory_regions.len()) * mem::size_of::<c_int>();
-            let cmsg_buffer = libc::malloc(CMSG_SPACE(cmsg_length as size_t)) as *mut cmsghdr;
-            (*cmsg_buffer).cmsg_len = CMSG_LEN(cmsg_length as size_t);
-            (*cmsg_buffer).cmsg_level = libc::SOL_SOCKET;
-            (*cmsg_buffer).cmsg_type = SCM_RIGHTS;
+            unsafe fn construct_header(channels: &[UnixChannel],
+                                       shared_memory_regions: &[UnixSharedMemory],
+                                       data_buffer: &[u8])
+                                       -> (msghdr, Box<iovec>) {
+                let cmsg_length =
+                    (channels.len() + shared_memory_regions.len()) * mem::size_of::<c_int>();
+                let cmsg_buffer = libc::malloc(CMSG_SPACE(cmsg_length as size_t)) as *mut cmsghdr;
+                (*cmsg_buffer).cmsg_len = CMSG_LEN(cmsg_length as size_t);
+                (*cmsg_buffer).cmsg_level = libc::SOL_SOCKET;
+                (*cmsg_buffer).cmsg_type = SCM_RIGHTS;
 
-            let mut fds = Vec::new();
-            for channel in channels.iter() {
-                fds.push(channel.fd());
-            }
-            for shared_memory_region in shared_memory_regions.iter() {
-                fds.push(shared_memory_region.fd);
-            }
-            ptr::copy_nonoverlapping(fds.as_ptr(),
-                                     cmsg_buffer.offset(1) as *mut _ as *mut c_int,
-                                     fds.len());
-            let mut cmsg_padding_ptr =
-                (cmsg_buffer.offset(1) as *mut _ as *mut c_int).offset(fds.len() as isize);
-            let cmsg_end =
-                (cmsg_buffer as *mut _ as *mut u8).offset(CMSG_SPACE(cmsg_length as size_t) as
-                                                          isize);
-            while (cmsg_padding_ptr as *mut u8) < cmsg_end {
-                *cmsg_padding_ptr = *DEV_NULL;
-                cmsg_padding_ptr = cmsg_padding_ptr.offset(1);
-            }
+                let mut fds = Vec::new();
+                for channel in channels.iter() {
+                    fds.push(channel.fd());
+                }
+                for shared_memory_region in shared_memory_regions.iter() {
+                    fds.push(shared_memory_region.fd);
+                }
+                ptr::copy_nonoverlapping(fds.as_ptr(),
+                                         cmsg_buffer.offset(1) as *mut _ as *mut c_int,
+                                         fds.len());
+                let mut cmsg_padding_ptr =
+                    (cmsg_buffer.offset(1) as *mut _ as *mut c_int).offset(fds.len() as isize);
+                let cmsg_end =
+                    (cmsg_buffer as *mut _ as *mut u8).offset(CMSG_SPACE(cmsg_length as size_t) as
+                                                              isize);
+                while (cmsg_padding_ptr as *mut u8) < cmsg_end {
+                    *cmsg_padding_ptr = *DEV_NULL;
+                    cmsg_padding_ptr = cmsg_padding_ptr.offset(1);
+                }
 
-            let mut iovec = iovec {
-                iov_base: data_buffer.as_ptr() as *const c_char as *mut c_char,
-                iov_len: data_buffer.len() as size_t,
+                // Put this on the heap so address remains stable across function return.
+                let mut iovec = Box::new(iovec {
+                    iov_base: data_buffer.as_ptr() as *const c_char as *mut c_char,
+                    iov_len: data_buffer.len() as size_t,
+                });
+
+                let msghdr = msghdr {
+                    msg_name: ptr::null_mut(),
+                    msg_namelen: 0,
+                    msg_iov: &mut *iovec,
+                    msg_iovlen: 1,
+                    msg_control: cmsg_buffer as *mut c_void,
+                    msg_controllen: CMSG_SPACE(cmsg_length as size_t),
+                    msg_flags: 0,
+                };
+
+                // Be sure to always return iovec -- whether the caller uses it or not --
+                // to prevent premature deallocation!
+                (msghdr, iovec)
             };
 
-            let msghdr = msghdr {
-                msg_name: ptr::null_mut(),
-                msg_namelen: 0,
-                msg_iov: &mut iovec,
-                msg_iovlen: 1,
-                msg_control: cmsg_buffer as *mut c_void,
-                msg_controllen: CMSG_SPACE(cmsg_length as size_t),
-                msg_flags: 0,
-            };
+            let (msghdr, _iovec) = construct_header(&channels, &shared_memory_regions, &data_buffer);
 
             let result = sendmsg(self.fd, &msghdr, 0);
+            libc::free(msghdr.msg_control);
 
             if result > 0 {
-                libc::free(cmsg_buffer as *mut c_void);
                 return Ok(())
             } else {
                 let error = UnixError::last();
                 if error.0 != libc::EMSGSIZE {
-                    libc::free(cmsg_buffer as *mut c_void);
                     return Err(error)
                 }
             }
@@ -202,8 +213,18 @@ impl UnixSender {
                           &mut maximum_send_size_len as *mut socklen_t) < 0 {
                 return Err(UnixError::last())
             }
+
+            // Create dedicated channel to send all but the first fragment.
+            // This way we avoid fragments of different messages interleaving in the receiver.
+            //
+            // The receiver end of the channel is sent with the first fragment
+            // along any other file descriptors that are to be transferred in the message.
+            let (dedicated_tx, dedicated_rx) = try!(channel());
+            channels.push(UnixChannel::Receiver(dedicated_rx));
+            let (msghdr, mut iovec) = construct_header(&channels, &shared_memory_regions, &data_buffer);
+
             let bytes_per_fragment = maximum_send_size - (mem::size_of::<u32>() * 2 +
-                CMSG_SPACE(cmsg_length as size_t) as usize + 256);
+                msghdr.msg_controllen as usize + 256);
 
             // Split up the packet into fragments.
             let mut byte_position = 0;
@@ -235,14 +256,14 @@ impl UnixSender {
                     sendmsg(self.fd, &msghdr, 0)
                 } else {
                     // Trailing fragment.
-                    libc::send(self.fd,
+                    libc::send(dedicated_tx.fd,
                                data_buffer.as_ptr() as *const c_void,
                                bytes_to_send as size_t,
                                0)
                 };
 
                 if result <= 0 {
-                    libc::free(cmsg_buffer as *mut c_void);
+                    libc::free(msghdr.msg_control);
                     return Err(UnixError::last())
                 }
 
@@ -250,7 +271,7 @@ impl UnixSender {
                 this_fragment_id = next_fragment_id;
             }
 
-            libc::free(cmsg_buffer as *mut c_void);
+            libc::free(msghdr.msg_control);
             Ok(())
         }
     }
@@ -692,37 +713,24 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
         }
 
         // Reassemble fragments.
-        let mut leftover_fragments = Vec::new();
+        //
+        // The initial fragment carries the receive end of a dedicated channel
+        // through which all the remaining fragments will be coming in.
+        let dedicated_rx = channels.pop().unwrap().to_receiver();
         while next_fragment_id != 0 {
             let mut cmsg = UnixCmsg::new(maximum_recv_size);
-            let bytes_read = try!(cmsg.recv(fd, blocking_mode)) as usize;
+            let bytes_read = try!(cmsg.recv(dedicated_rx.fd, blocking_mode)) as usize;
 
             let this_fragment_id =
                 (&cmsg.data_buffer[0..mem::size_of::<u32>()]).read_u32::<LittleEndian>().unwrap();
-            if this_fragment_id != next_fragment_id {
-                // Not the fragment we're looking for. Save it and continue.
-                leftover_fragments.push(cmsg);
-                continue
-            }
+            assert!(this_fragment_id == next_fragment_id);
 
-            // OK, it's the next fragment in the chain. Store its data.
             next_fragment_id =
                 (&cmsg.data_buffer[mem::size_of::<u32>()..
                                    (mem::size_of::<u32>() * 2)]).read_u32::<LittleEndian>()
                                                                 .unwrap();
             main_data_buffer.extend(
                     cmsg.data_buffer[(mem::size_of::<u32>() * 2)..bytes_read].iter().cloned())
-        }
-
-        // Push back any leftovers. Do this in a separate thread to avoid deadlocks (e.g. #34).
-        if !leftover_fragments.is_empty() {
-            let fd_for_helper_thread = libc::dup(fd);
-            thread::spawn(move || {
-                for mut leftover_fragment in leftover_fragments.into_iter() {
-                    drop(leftover_fragment.send(fd_for_helper_thread));
-                }
-                libc::close(fd_for_helper_thread);
-            });
         }
 
         Ok((main_data_buffer, channels, shared_memory_regions))
@@ -846,15 +854,6 @@ impl UnixCmsg {
             }
         }
         result
-    }
-
-    unsafe fn send(&mut self, fd: c_int) -> Result<(), UnixError> {
-        let result = sendmsg(fd, &mut self.msghdr, 0);
-        if result > 0 {
-            Ok(())
-        } else {
-            Err(UnixError::last())
-        }
     }
 
     unsafe fn cmsg_len(&self) -> size_t {

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -170,6 +170,43 @@ fn big_data_with_sender_transfer() {
 }
 
 #[test]
+fn concurrent_senders() {
+    let num_senders = 3;
+
+    let (tx, rx) = platform::channel().unwrap();
+
+    let threads: Vec<_> = (0..num_senders).map(|i| {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            let data: Vec<u8> = iter::repeat(i).take(1024 * 1024).collect();
+            let data: &[u8] = &data[..];
+            tx.send(data, vec![], vec![]).unwrap();
+        })
+    }).collect();
+
+    let mut received_vals: Vec<u8> = vec![];
+    for _ in 0..num_senders {
+        let (mut received_data, received_channels, received_shared_memory_regions) =
+            rx.recv().unwrap();
+        let val = received_data[0];
+        received_vals.push(val);
+        let data: Vec<u8> = iter::repeat(val).take(1024 * 1024).collect();
+        let data: &[u8] = &data[..];
+        received_data.truncate(1024 * 1024);
+        assert_eq!(received_data.len(), data.len());
+        assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
+                   (&data[..], vec![], vec![]));
+    }
+    assert!(rx.try_recv().is_err()); // There should be no further messages pending.
+    received_vals.sort();
+    assert_eq!(received_vals, (0..num_senders).collect::<Vec<_>>()); // Got exactly the values we sent.
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}
+
+#[test]
 fn receiver_set() {
     let (tx0, rx0) = platform::channel().unwrap();
     let (tx1, rx1) = platform::channel().unwrap();


### PR DESCRIPTION
As evidenced by the newly added "concurrent_senders" test case, the
previous approach never actually worked with concurrent large transfers:
when trying to "push back" packets to the "receiver" FD of the socket
pair, they do not show up on the "receiver" FD again, but rather the
"sender" FD.

This problem can be avoided entirely by automatically creating a
dedicated channel for each large transfer, so the followup fragments can
all be received in order, without interleaving with fragments from other
senders.

The first fragment of each large transfer is still sent through the main
channel, along with an FD for the dedicated channel; the remaining
fragments are then sent through the dedicated channel.

This approach adds a slight overhead for fragmented transfers when there
is no actual concurrency -- though it is way more efficient when actual
concurrency occurs than the push-back approach would have been...

With the dedicated channel, the follow-up fragments do not really need
the fragmentation headers anymore; and the header for the initial
fragment could be simplified as well. However, to keep changes minimal,
this commit doesn't change the header yet -- this is left for later
improvements.