### PR TITLE
Pin serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "ipc_channel"
 path = "lib.rs"
 
 [dependencies.serde]
+version = "0.6"
 opt_level = 2
 
 [dependencies.bincode]


### PR DESCRIPTION
r? @pcwalton 

There's a serde update (to 0.7) that we can't pick up or it will break bincode. This is paired with an update to bincode that also pins serde back to 0.6.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/ipc-channel/43)
<!-- Reviewable:end -->
