### PR TITLE
Linux: Always use blocking receive for followup fragments

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -9,6 +9,7 @@
 
 #![feature(custom_derive, plugin, slice_patterns)]
 #![feature(mpsc_select, borrow_state)]
+#![cfg_attr(test, feature(time2))]
 #![plugin(serde_macros)]
 
 #[macro_use]

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -720,7 +720,10 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
         let dedicated_rx = channels.pop().unwrap().to_receiver();
         while next_fragment_id != 0 {
             let mut cmsg = UnixCmsg::new(maximum_recv_size);
-            let bytes_read = try!(cmsg.recv(dedicated_rx.fd, blocking_mode)) as usize;
+            // Always use blocking mode for followup fragments,
+            // to make sure that once we start receiving a multi-fragment message,
+            // we don't abort in the middle of it...
+            let bytes_read = try!(cmsg.recv(dedicated_rx.fd, BlockingMode::Blocking)) as usize;
 
             let this_fragment_id =
                 (&cmsg.data_buffer[0..mem::size_of::<u32>()]).read_u32::<LittleEndian>().unwrap();

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -10,6 +10,8 @@
 use libc;
 use platform::{self, OsIpcChannel, OsIpcReceiverSet, OsIpcSender, OsIpcOneShotServer};
 use platform::{OsIpcSharedMemory};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use std::thread;
 
 #[test]
@@ -364,3 +366,105 @@ fn try_recv() {
     assert!(rx.try_recv().is_err());
 }
 
+#[test]
+fn try_recv_large() {
+    let (tx, rx) = platform::channel().unwrap();
+    assert!(rx.try_recv().is_err());
+
+    let thread = thread::spawn(move || {
+        let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        let data: &[u8] = &data[..];
+        tx.send(data, vec![], vec![]).unwrap();
+    });
+
+    let mut result;
+    while {
+        result = rx.try_recv();
+        result.is_err()
+    } {}
+    thread.join().unwrap();
+    let (mut received_data, received_channels, received_shared_memory) = result.unwrap();
+
+    let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
+    let data: &[u8] = &data[..];
+    received_data.truncate(1024 * 1024);
+    assert_eq!((&received_data[..], received_channels, received_shared_memory),
+               (data, vec![], vec![]));
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn try_recv_large_delayed() {
+    // These settings work well on my system when doing cargo test --release.
+    // Haven't found a good way to test this with non-release builds...
+    let num_senders = 10;
+    let thread_delay = 50;
+    let msg_size = 512 * 1024;
+
+    let delay = {
+        fn delay_iterations(iterations: u64) {
+            // Let's hope rustc won't ever be able to optimise this away...
+            let mut v = vec![];
+            for _ in 0..iterations {
+                v.push(0);
+                v.pop();
+            }
+        }
+
+        let iterations_per_ms;
+        {
+            let (mut iterations, mut time_per_run) = (1u64, Duration::new(0, 0));
+            while time_per_run < Duration::new(0, 10_000_000) {
+                iterations *= 10;
+                let start = Instant::now();
+                delay_iterations(iterations);
+                time_per_run = start.elapsed();
+            }
+            // This assumes time_per_run stays below one second.
+            // Unless something weird happens, we shoud be safely within this margin...
+            iterations_per_ms = iterations * 1_000_000 / time_per_run.subsec_nanos() as u64;
+        }
+
+        Arc::new(move |ms: u64| delay_iterations(ms * iterations_per_ms))
+    };
+
+    let (tx, rx) = platform::channel().unwrap();
+    assert!(rx.try_recv().is_err());
+
+    let threads: Vec<_> = (0..num_senders).map(|i| {
+        let tx = tx.clone();
+        let delay = delay.clone();
+        thread::spawn(move || {
+            let data: Vec<u8> = (0..msg_size).map(|j| (j % 13) as u8 | i << 4).collect();
+            let data: &[u8] = &data[..];
+            delay(thread_delay);
+            tx.send(data, vec![], vec![]).unwrap();
+        })
+    }).collect();
+
+    let mut received_vals: Vec<u8> = vec![];
+    for _ in 0..num_senders {
+        let mut result;
+        while {
+            result = rx.try_recv();
+            result.is_err()
+        } {}
+        let (mut received_data, received_channels, received_shared_memory) = result.unwrap();
+        received_data.truncate(msg_size);
+
+        let val = received_data[0] >> 4;
+        received_vals.push(val);
+        let data: Vec<u8> = (0..msg_size).map(|j| (j % 13) as u8 | val << 4).collect();
+        let data: &[u8] = &data[..];
+        assert_eq!(received_data.len(), data.len());
+        assert_eq!((&received_data[..], received_channels, received_shared_memory),
+                   (data, vec![], vec![]));
+    }
+    assert!(rx.try_recv().is_err()); // There should be no further messages pending.
+    received_vals.sort();
+    assert_eq!(received_vals, (0..num_senders).collect::<Vec<_>>()); // Got exactly the values we sent.
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}


### PR DESCRIPTION
Fixes an issue (see commit message for details) that I discovered in the code while working on other stuff. I don't know how likely it is to manifest in real life; but it seems entirely likely that it's causing some spurious failures now and again...

The PR also includes a commit with improvements to several unrelated test cases, which I didn't want to untangle from the main commit with the newly added tests. It should do no harm.