### PR TITLE
Introduce `IpcBytesSender` and `IpcBytesReceiver` types for fast transfer of binary blobs.

### DIFF
--- a/test.rs
+++ b/test.rs
@@ -409,3 +409,24 @@ fn multiple_paths_to_a_sender() {
     assert_eq!(received_person, person);
 }
 
+#[test]
+fn bytes() {
+    let bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+    let (tx, rx) = ipc::bytes_channel().unwrap();
+    tx.send(&bytes[..]).unwrap();
+    let received_bytes = rx.recv().unwrap();
+    assert_eq!(&bytes, &received_bytes[..]);
+}
+
+#[test]
+fn embedded_bytes_receivers() {
+    let (sub_tx, sub_rx) = ipc::bytes_channel().unwrap();
+    let (super_tx, super_rx) = ipc::channel().unwrap();
+    super_tx.send(sub_tx).unwrap();
+    let sub_tx = super_rx.recv().unwrap();
+    let bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+    sub_tx.send(&bytes[..]).unwrap();
+    let received_bytes = sub_rx.recv().unwrap();
+    assert_eq!(&bytes, &received_bytes[..]);
+}
+


### PR DESCRIPTION
`serde`/`bincode` is very slow at serializing and deserializing
`Vec<u8>`, and shared memory involves too many syscalls (at least on the
Mac).

r? @jdm