### PR TITLE
tests: Fix truncate() size

### DIFF
--- a/platform/test.rs
+++ b/platform/test.rs
@@ -163,7 +163,7 @@ fn big_data_with_sender_transfer() {
     sub_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(1024 * 1024);
+    received_data.truncate(65536);
     assert_eq!(received_data.len(), data.len());
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));


### PR DESCRIPTION
Fixes a copy-paste error in one of the truncate calls.

This doesn't seem to change anything really; and quite frankly, I have
no idea why these truncate() calls are even there at all... But while
they are, let's make them correct at least.