### PR TITLE
Fix bugs in handling of socket addresses

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -288,7 +288,7 @@ impl UnixSender {
             };
             libc::strncpy(sockaddr.sun_path.as_mut_ptr(),
                           name.as_ptr(),
-                          sockaddr.sun_path.len() as size_t);
+                          sockaddr.sun_path.len() as size_t - 1);
 
             let len = mem::size_of::<c_short>() +
                 (libc::strlen(sockaddr.sun_path.as_ptr()) as usize);
@@ -469,7 +469,7 @@ impl UnixOneShotServer {
                 };
                 libc::strncpy(sockaddr.sun_path.as_mut_ptr(),
                               path.as_ptr() as *const c_char,
-                              sockaddr.sun_path.len() as size_t);
+                              sockaddr.sun_path.len() as size_t - 1);
 
                 let len = mem::size_of::<c_short>() + (libc::strlen(sockaddr.sun_path.as_ptr()) as
                                                        usize);

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -459,7 +459,7 @@ impl UnixOneShotServer {
             loop {
                 let path_string = CString::new(b"/tmp/rust-ipc-socket.XXXXXX" as &[u8]).unwrap();
                 path = path_string.as_bytes().iter().cloned().collect();
-                if mktemp(path.as_mut_ptr() as *mut c_char) == ptr::null_mut() {
+                if *mktemp(path.as_mut_ptr() as *mut c_char) == 0 {
                     return Err(UnixError::last())
                 }
 

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -458,7 +458,7 @@ impl UnixOneShotServer {
             let mut path: Vec<u8>;
             loop {
                 let path_string = CString::new(b"/tmp/rust-ipc-socket.XXXXXX" as &[u8]).unwrap();
-                path = path_string.as_bytes().iter().cloned().collect();
+                path = path_string.as_bytes_with_nul().iter().cloned().collect();
                 if *mktemp(path.as_mut_ptr() as *mut c_char) == 0 {
                     return Err(UnixError::last())
                 }


### PR DESCRIPTION
The main commit (the third one, about obtaining '\0'-terminated C strings) addresses a pretty serious bug, which is quite likely causing some intermittent failures. The others are minor.

This also includes a commit with general improvement to some existing test cases, which is not strictly related to the issue at hand, but helped debugging it.