### PR TITLE
Test: data is recv-able after sender is dropped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
+*.swp
+*.swo
 target
 Cargo.lock

--- a/test.rs
+++ b/test.rs
@@ -456,3 +456,14 @@ fn embedded_bytes_receivers() {
     assert_eq!(&bytes, &received_bytes[..]);
 }
 
+#[test]
+fn test_so_linger() {
+    let (sender, receiver) = ipc::channel().unwrap();
+    sender.send(42).unwrap();
+    drop(sender);
+    let val = match receiver.recv() {
+        Ok(val) => val,
+        Err(e) => { panic!("err: `{}`", e); }
+    };
+    assert_eq!(val, 42);
+}


### PR DESCRIPTION
Add test for #30. Test that data can be retrieved from the receiver
after the sender has been dropped.

Fixes: #33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/ipc-channel/58)
<!-- Reviewable:end -->
