### PR TITLE
Linux: UnixCmsg: Don't deduce maximum cmsg size from data size

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -806,12 +806,11 @@ impl UnixCmsg {
         let cmsg_length = mem::size_of::<cmsghdr>() + (MAX_FDS_IN_CMSG as usize) *
             mem::size_of::<c_int>();
         assert!(maximum_recv_size > cmsg_length);
-        let data_length = maximum_recv_size - cmsg_length;
-        let mut data_buffer: Vec<u8> = vec![0; data_length];
+        let mut data_buffer: Vec<u8> = vec![0; maximum_recv_size];
         let cmsg_buffer = libc::malloc(cmsg_length as size_t) as *mut cmsghdr;
         let mut iovec = Box::new(iovec {
             iov_base: &mut data_buffer[0] as *mut _ as *mut c_char,
-            iov_len: data_length as size_t,
+            iov_len: data_buffer.len(),
         });
         let iovec_ptr: *mut iovec = &mut *iovec;
         UnixCmsg {


### PR DESCRIPTION
@antrik committed 10f4032:
> Just because we allocate a generous receive buffer for auxilllary data,
> doesn't mean that a message can't use the space for other things when it
> doesn't actually carry that amount of auxillary data.
> 
> In fact, there is no reason to expect every message we receive to have
> auxillary data at all -- so let's just allocate a data buffer matching
> the total maximal receive size. This will enable some optimisations to
> be implemented; and it simplifies the code too.
> 
> Note that the extra space is not used yet, until the sender side is
> adapted to actually send larger messages making use of the extra space.
> (Or even messages without auxillary data.)

This also fixes servo/servo#10260, but unlike #59, it's not just a hack.
I've put this up as a PR because @antrik might not get to it for a few days.
cc @Manishearth @pcwalton