### PR TITLE
Linux: Fix receive for message sizes close to packet size

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -114,6 +114,22 @@ impl UnixSender {
         }
     }
 
+    /// Maximum total data size that can be transferred over this channel in a single packet.
+    pub fn get_maximum_send_size(&self) -> Result<usize,UnixError> {
+        unsafe {
+            let mut maximum_send_size: usize = 0;
+            let mut maximum_send_size_len = mem::size_of::<usize>() as socklen_t;
+            if getsockopt(self.fd,
+                          libc::SOL_SOCKET,
+                          libc::SO_SNDBUF,
+                          &mut maximum_send_size as *mut usize as *mut c_void,
+                          &mut maximum_send_size_len as *mut socklen_t) < 0 {
+                return Err(UnixError::last())
+            }
+            Ok(maximum_send_size)
+        }
+    }
+
     pub fn send(&self,
                 data: &[u8],
                 mut channels: Vec<UnixChannel>,
@@ -197,17 +213,8 @@ impl UnixSender {
                 }
             }
 
-            // The packet is too big. Fragmentation time! First, determine our maximum sending size.
-            let mut maximum_send_size: usize = 0;
-            let mut maximum_send_size_len = mem::size_of::<usize>() as socklen_t;
-            if getsockopt(self.fd,
-                          libc::SOL_SOCKET,
-                          libc::SO_SNDBUF,
-                          &mut maximum_send_size as *mut usize as *mut c_void,
-                          &mut maximum_send_size_len as *mut socklen_t) < 0 {
-                return Err(UnixError::last())
-            }
-
+            // The packet is too big. Fragmentation time!
+            //
             // Create dedicated channel to send all but the first fragment.
             // This way we avoid fragments of different messages interleaving in the receiver.
             //
@@ -217,8 +224,9 @@ impl UnixSender {
             channels.push(UnixChannel::Receiver(dedicated_rx));
             let (msghdr, mut iovec) = construct_header(&channels, &shared_memory_regions, &data_buffer);
 
-            let mut bytes_per_fragment = maximum_send_size - (mem::size_of::<u32>() * 2 +
-                msghdr.msg_controllen as usize + 256);
+            let mut bytes_per_fragment = try!(self.get_maximum_send_size())
+                                         - (mem::size_of::<u32>() * 2
+                                            + msghdr.msg_controllen as usize + 256);
 
             // Split up the packet into fragments.
             let mut byte_position = 0;

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -832,12 +832,11 @@ impl UnixCmsg {
         let cmsg_length = mem::size_of::<cmsghdr>() + (MAX_FDS_IN_CMSG as usize) *
             mem::size_of::<c_int>();
         assert!(maximum_recv_size > cmsg_length);
-        let data_length = maximum_recv_size - cmsg_length;
-        let mut data_buffer: Vec<u8> = vec![0; data_length];
+        let mut data_buffer: Vec<u8> = vec![0; maximum_recv_size];
         let cmsg_buffer = libc::malloc(cmsg_length as size_t) as *mut cmsghdr;
         let mut iovec = Box::new(iovec {
             iov_base: &mut data_buffer[0] as *mut _ as *mut c_char,
-            iov_len: data_length as size_t,
+            iov_len: data_buffer.len(),
         });
         let iovec_ptr: *mut iovec = &mut *iovec;
         UnixCmsg {


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/10260

This supersedes https://github.com/servo/ipc-channel/pull/60 -- which is basically the same change; but now we have a test case, and an improved commit message. (Pointing out the bug fix; and also fixing a very confusing typo in the title...)

The extra commit does some refactoring necessary for the new test case.