### PR TITLE
Handle ENOBUFS by dynamically reducing packet size

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -25,9 +25,6 @@ use std::thread;
 
 const MAX_FDS_IN_CMSG: u32 = 64;
 
-// Limit the send/receive buffers to 32kB.
-const BUFFER_SIZE: c_int = 32 * 1024;
-
 // Yes, really!
 const MAP_FAILED: *mut u8 = (!0usize) as *mut u8;
 
@@ -37,18 +34,7 @@ pub fn channel() -> Result<(UnixSender, UnixReceiver),UnixError> {
     let mut results = [0, 0];
     unsafe {
         if socketpair(libc::AF_UNIX, SOCK_SEQPACKET, 0, &mut results[0]) >= 0 {
-            let (a, b) = (results[0], results[1]);
-
-            let set_size = |sock, which| {
-                setsockopt(sock, libc::SOL_SOCKET, which,
-                           &BUFFER_SIZE as *const c_int as *const c_void,
-                           mem::size_of::<c_int>() as socklen_t);
-            };
-            set_size(a, libc::SO_SNDBUF);
-            set_size(a, libc::SO_RCVBUF);
-            set_size(b, libc::SO_SNDBUF);
-            set_size(b, libc::SO_RCVBUF);
-            Ok((UnixSender::from_fd(a), UnixReceiver::from_fd(b)))
+            Ok((UnixSender::from_fd(results[0]), UnixReceiver::from_fd(results[1])))
         } else {
             Err(UnixError::last())
         }


### PR DESCRIPTION
This is a better fix for https://github.com/servo/servo/issues/9555 : handling the problem when it actually occurs, without affecting performance otherwise.

It obsoletes (and removes) the workaround in https://github.com/servo/ipc-channel/pull/57