### PR TITLE
Optimisations (and cleanups) of Linux backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ rand = "0.3"
 serde = ">=0.6, <0.8"
 serde_macros = ">=0.6, <0.8"
 uuid = { version = "0.2", features = ["v4"] }
+
+[dev-dependencies]
+crossbeam = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ path = "lib.rs"
 
 [dependencies]
 bincode = ">=0.4.1, <0.6"
-byteorder = "0.5"
 lazy_static = "0.2"
 libc = "0.2"
 rand = "0.3"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -25,7 +25,7 @@ fn bench_size(b: &mut test::Bencher, size: usize) {
     let (wait_tx, wait_rx) = mpsc::channel();
     let wait_rx = Mutex::new(wait_rx);
 
-    if size > tx.get_max_fragment_size().unwrap() {
+    if size > platform::OsIpcSender::get_max_fragment_size() {
         b.iter(|| {
             crossbeam::scope(|scope| {
                 scope.spawn(|| {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,183 @@
+#![feature(test)]
+
+extern crate crossbeam;
+extern crate ipc_channel;
+extern crate test;
+
+use ipc_channel::platform;
+
+use std::sync::{mpsc, Mutex};
+
+/// Allows doing multiple inner iterations per bench.iter() run.
+///
+/// This is mostly to amortise the overhead of spawning a thread in the benchmark
+/// when sending larger messages (that might be fragmented).
+///
+/// Note that you need to compensate the displayed results
+/// for the proportionally longer runs yourself,
+/// as the benchmark framework doesn't know about the inner iterations...
+const ITERATIONS: usize = 1;
+
+fn bench_size(b: &mut test::Bencher, size: usize) {
+    let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+    let (tx, rx) = platform::channel().unwrap();
+
+    let (wait_tx, wait_rx) = mpsc::channel();
+    let wait_rx = Mutex::new(wait_rx);
+
+    if size > tx.get_max_fragment_size().unwrap() {
+        b.iter(|| {
+            crossbeam::scope(|scope| {
+                scope.spawn(|| {
+                    let wait_rx = wait_rx.lock().unwrap();
+                    for _ in 0..ITERATIONS {
+                        tx.send(&data, vec![], vec![]).unwrap();
+                        if ITERATIONS > 1 {
+                            // Prevent beginning of the next send
+                            // from overlapping with receive of last fragment,
+                            // as otherwise results of runs with a large tail fragment
+                            // are significantly skewed.
+                            wait_rx.recv().unwrap();
+                        }
+                    }
+                });
+                for _ in 0..ITERATIONS {
+                    rx.recv().unwrap();
+                    if ITERATIONS > 1 {
+                        wait_tx.send(()).unwrap();
+                    }
+                }
+                // For reasons mysterious to me,
+                // not returning a value *from every branch*
+                // adds some 100 ns or so of overhead to all results --
+                // which is quite significant for very short tests...
+                0
+            })
+        });
+    } else {
+        b.iter(|| {
+            for _ in 0..ITERATIONS {
+                tx.send(&data, vec![], vec![]).unwrap();
+                rx.recv().unwrap();
+            }
+            0
+        });
+    }
+}
+
+// It turns out the results have some crazy jumps between sizes,
+// probably related to some allocator alignment stuff.
+// What's more, these fluctuate strongly in seemingly random ways
+// in response to various changes to the test setup etc.
+//
+// Warming up the memory somewhat mitigates these issues.
+// The specific size used here was determined empirically
+// to produce comparatively sane results -- on my system at least.
+// (Maybe because it doesn't align well with 2's complements...
+// Or maybe it's just an entirely random effect.)
+//
+// There might be more elegant and/or more effective ways to do the warm-up,
+// using random allocations or something along these lines...
+// However, I don't think it's really *that* important --
+// and I already spent way too much time trying to figure this out :-(
+#[bench]
+fn _invoke_chaos(b: &mut test::Bencher) {
+    bench_size(b, 777_777); // 111-up the beast ;-)
+}
+
+#[bench]
+fn size_00_1(b: &mut test::Bencher) {
+    bench_size(b, 1);
+}
+#[bench]
+fn size_01_2(b: &mut test::Bencher) {
+    bench_size(b, 2);
+}
+#[bench]
+fn size_02_4(b: &mut test::Bencher) {
+    bench_size(b, 4);
+}
+#[bench]
+fn size_03_8(b: &mut test::Bencher) {
+    bench_size(b, 8);
+}
+#[bench]
+fn size_04_16(b: &mut test::Bencher) {
+    bench_size(b, 16);
+}
+#[bench]
+fn size_05_32(b: &mut test::Bencher) {
+    bench_size(b, 32);
+}
+#[bench]
+fn size_06_64(b: &mut test::Bencher) {
+    bench_size(b, 64);
+}
+#[bench]
+fn size_07_128(b: &mut test::Bencher) {
+    bench_size(b, 128);
+}
+#[bench]
+fn size_08_256(b: &mut test::Bencher) {
+    bench_size(b, 256);
+}
+#[bench]
+fn size_09_512(b: &mut test::Bencher) {
+    bench_size(b, 512);
+}
+#[bench]
+fn size_10_1k(b: &mut test::Bencher) {
+    bench_size(b, 1 * 1024);
+}
+#[bench]
+fn size_11_2k(b: &mut test::Bencher) {
+    bench_size(b, 2 * 1024);
+}
+#[bench]
+fn size_12_4k(b: &mut test::Bencher) {
+    bench_size(b, 4 * 1024);
+}
+#[bench]
+fn size_13_8k(b: &mut test::Bencher) {
+    bench_size(b, 8 * 1024);
+}
+#[bench]
+fn size_14_16k(b: &mut test::Bencher) {
+    bench_size(b, 16 * 1024);
+}
+#[bench]
+fn size_15_32k(b: &mut test::Bencher) {
+    bench_size(b, 32 * 1024);
+}
+#[bench]
+fn size_16_64k(b: &mut test::Bencher) {
+    bench_size(b, 64 * 1024);
+}
+#[bench]
+fn size_17_128k(b: &mut test::Bencher) {
+    bench_size(b, 128 * 1024);
+}
+#[bench]
+fn size_18_256k(b: &mut test::Bencher) {
+    bench_size(b, 256 * 1024);
+}
+#[bench]
+fn size_19_512k(b: &mut test::Bencher) {
+    bench_size(b, 512 * 1024);
+}
+#[bench]
+fn size_20_1m(b: &mut test::Bencher) {
+    bench_size(b, 1 * 1024 * 1024);
+}
+#[bench]
+fn size_21_2m(b: &mut test::Bencher) {
+    bench_size(b, 2 * 1024 * 1024);
+}
+#[bench]
+fn size_22_4m(b: &mut test::Bencher) {
+    bench_size(b, 4 * 1024 * 1024);
+}
+#[bench]
+fn size_23_8m(b: &mut test::Bencher) {
+    bench_size(b, 8 * 1024 * 1024);
+}

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -65,26 +65,6 @@ fn bench_size(b: &mut test::Bencher, size: usize) {
     }
 }
 
-// It turns out the results have some crazy jumps between sizes,
-// probably related to some allocator alignment stuff.
-// What's more, these fluctuate strongly in seemingly random ways
-// in response to various changes to the test setup etc.
-//
-// Warming up the memory somewhat mitigates these issues.
-// The specific size used here was determined empirically
-// to produce comparatively sane results -- on my system at least.
-// (Maybe because it doesn't align well with 2's complements...
-// Or maybe it's just an entirely random effect.)
-//
-// There might be more elegant and/or more effective ways to do the warm-up,
-// using random allocations or something along these lines...
-// However, I don't think it's really *that* important --
-// and I already spent way too much time trying to figure this out :-(
-#[bench]
-fn _invoke_chaos(b: &mut test::Bencher) {
-    bench_size(b, 777_777); // 111-up the beast ;-)
-}
-
 #[bench]
 fn size_00_1(b: &mut test::Bencher) {
     bench_size(b, 1);

--- a/lib.rs
+++ b/lib.rs
@@ -16,7 +16,6 @@
 extern crate lazy_static;
 
 extern crate bincode;
-extern crate byteorder;
 extern crate libc;
 extern crate rand;
 extern crate serde;

--- a/platform/inprocess/mod.rs
+++ b/platform/inprocess/mod.rs
@@ -18,6 +18,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::cmp::{PartialEq};
 use std::ops::Deref;
 use std::mem;
+use std::usize;
 
 use uuid::Uuid;
 
@@ -146,6 +147,10 @@ impl MpscSender {
         let record = ONE_SHOT_SERVERS.lock().unwrap().remove(&name).unwrap();
         record.connect();
         Ok(record.sender)
+    }
+
+    pub fn get_max_fragment_size(&self) -> Result<usize,()> {
+        Ok(usize::MAX)
     }
 
     pub fn send(&self,

--- a/platform/inprocess/mod.rs
+++ b/platform/inprocess/mod.rs
@@ -149,8 +149,8 @@ impl MpscSender {
         Ok(record.sender)
     }
 
-    pub fn get_max_fragment_size(&self) -> Result<usize,()> {
-        Ok(usize::MAX)
+    pub fn get_max_fragment_size() -> usize {
+        usize::MAX
     }
 
     pub fn send(&self,

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -30,7 +30,8 @@ const MAP_FAILED: *mut u8 = (!0usize) as *mut u8;
 
 // The value Linux returns for SO_SNDBUF
 // is not the size we are actually allowed to use...
-const RESERVED_SIZE: usize = 256;
+// Empirically, we have to deduct 32 bytes from that.
+const RESERVED_SIZE: usize = 32;
 
 static LAST_FRAGMENT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -201,7 +201,7 @@ impl UnixSender {
                                          fds.len());
 
                 // Put this on the heap so address remains stable across function return.
-                let mut iovec = Box::new(iovec {
+                let iovec = Box::new(iovec {
                     iov_base: data_buffer.as_ptr() as *const c_char as *mut c_char,
                     iov_len: data_buffer.len(),
                 });
@@ -209,7 +209,7 @@ impl UnixSender {
                 let msghdr = msghdr {
                     msg_name: ptr::null_mut(),
                     msg_namelen: 0,
-                    msg_iov: &mut *iovec,
+                    msg_iov: &*iovec,
                     msg_iovlen: 1,
                     msg_control: cmsg_buffer as *mut c_void,
                     msg_controllen: CMSG_SPACE(cmsg_length),
@@ -868,11 +868,11 @@ impl UnixCmsg {
         assert!(maximum_recv_size > cmsg_length);
         let mut data_buffer: Vec<u8> = vec![0; maximum_recv_size];
         let cmsg_buffer = libc::malloc(cmsg_length) as *mut cmsghdr;
-        let mut iovec = Box::new(iovec {
+        let iovec = Box::new(iovec {
             iov_base: &mut data_buffer[0] as *mut _ as *mut c_char,
             iov_len: data_buffer.len(),
         });
-        let iovec_ptr: *mut iovec = &mut *iovec;
+        let iovec_ptr: *const iovec = &*iovec;
         UnixCmsg {
             data_buffer: data_buffer,
             cmsg_buffer: cmsg_buffer,
@@ -988,7 +988,7 @@ extern {
 struct msghdr {
     msg_name: *mut c_void,
     msg_namelen: socklen_t,
-    msg_iov: *mut iovec,
+    msg_iov: *const iovec,
     msg_iovlen: size_t,
     msg_control: *mut c_void,
     msg_controllen: size_t,

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -154,7 +154,8 @@ impl UnixSender {
     /// i.e. the value of *SYSTEM_SENDBUF_SIZE --
     /// except after getting ENOBUFS, in which case it needs to be reduced.
     fn fragment_size(sendbuf_size: usize) -> usize {
-        sendbuf_size - RESERVED_SIZE - mem::size_of::<usize>()
+        (sendbuf_size - RESERVED_SIZE - mem::size_of::<usize>())
+            & (!8usize + 1) // Ensure optimal alignment.
     }
 
     /// Maximum data size that can be transferred over this channel in a single packet.

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -157,7 +157,7 @@ impl UnixSender {
 
         unsafe {
             unsafe fn construct_header(fds: &[c_int], data_buffer: &[u8]) -> (msghdr, Box<iovec>) {
-                let cmsg_length = fds.len() * mem::size_of::<c_int>();
+                let cmsg_length = mem::size_of_val(fds);
                 let cmsg_buffer = libc::malloc(CMSG_SPACE(cmsg_length)) as *mut cmsghdr;
                 (*cmsg_buffer).cmsg_len = CMSG_LEN(cmsg_length);
                 (*cmsg_buffer).cmsg_level = libc::SOL_SOCKET;

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -739,7 +739,7 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
         // through which all the remaining fragments will be coming in.
         let dedicated_rx = channels.pop().unwrap().to_receiver();
         while next_fragment_id != 0 {
-            let mut cmsg = UnixCmsg::new(maximum_recv_size);
+            let mut cmsg = UnixCmsg::new(maximum_recv_size - RESERVED_SIZE);
             // Always use blocking mode for followup fragments,
             // to make sure that once we start receiving a multi-fragment message,
             // we don't abort in the middle of it...

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -227,8 +227,7 @@ impl UnixSender {
             let (msghdr, mut iovec) = construct_header(&fds[..], &data_buffer[..]);
 
             let mut bytes_per_fragment = try!(self.get_system_sendbuf_size())
-                                         - (mem::size_of::<u32>() * 2
-                                            + msghdr.msg_controllen + 256);
+                                         - (mem::size_of::<u32>() * 2 + 256);
 
             // Split up the packet into fragments.
             let mut byte_position = 0;

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -28,6 +28,10 @@ const MAX_FDS_IN_CMSG: u32 = 64;
 // Yes, really!
 const MAP_FAILED: *mut u8 = (!0usize) as *mut u8;
 
+// The value Linux returns for SO_SNDBUF
+// is not the size we are actually allowed to use...
+const RESERVED_SIZE: usize = 256;
+
 static LAST_FRAGMENT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
 pub fn channel() -> Result<(UnixSender, UnixReceiver),UnixError> {
@@ -227,7 +231,7 @@ impl UnixSender {
             let (msghdr, mut iovec) = construct_header(&fds[..], &data_buffer[..]);
 
             let mut bytes_per_fragment = try!(self.get_system_sendbuf_size())
-                                         - (mem::size_of::<u32>() * 2 + 256);
+                                         - (mem::size_of::<u32>() * 2 + RESERVED_SIZE);
 
             // Split up the packet into fragments.
             let mut byte_position = 0;

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -740,9 +740,8 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
         // or need to receive additional fragments -- and if so, how much.
         let mut total_size = 0usize;
         // Allocate a buffer without initialising the memory.
-        let mut main_data_buffer = Vec::with_capacity(*SYSTEM_SENDBUF_SIZE
-                                                      - mem::size_of_val(&total_size));
-        main_data_buffer.set_len(*SYSTEM_SENDBUF_SIZE - mem::size_of_val(&total_size));
+        let mut main_data_buffer = Vec::with_capacity(UnixSender::get_max_fragment_size());
+        main_data_buffer.set_len(UnixSender::get_max_fragment_size());
 
         let iovec = [
             iovec {

--- a/platform/macos/mod.rs
+++ b/platform/macos/mod.rs
@@ -23,6 +23,7 @@ use std::mem;
 use std::ops::Deref;
 use std::ptr;
 use std::slice;
+use std::usize;
 
 mod mach_sys;
 
@@ -363,6 +364,10 @@ impl MachSender {
                 Err(MachError(os_result))
             }
         }
+    }
+
+    pub fn get_max_fragment_size(&self) -> Result<usize,()> {
+        Ok(usize::MAX)
     }
 
     pub fn send(&self,

--- a/platform/macos/mod.rs
+++ b/platform/macos/mod.rs
@@ -366,8 +366,8 @@ impl MachSender {
         }
     }
 
-    pub fn get_max_fragment_size(&self) -> Result<usize,()> {
-        Ok(usize::MAX)
+    pub fn get_max_fragment_size() -> usize {
+        usize::MAX
     }
 
     pub fn send(&self,

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -182,13 +182,12 @@ fn full_packet() {
 
     // Should be the biggest size that just fits in a single packet.
     //
-    // 32 is the empirical minimal size of the "control message" header,
-    // which we presently always send along with the data;
+    // 32 is the empirical size reseved by the kernel;
     // the rest is for the fragment header.
     //
     // Note that this calculation might become imprecise
     // when certain implementation details of the send() method change...
-    let size = tx.get_maximum_send_size().unwrap() - 32 - mem::size_of::<u32>() * 2;
+    let size = tx.get_system_sendbuf_size().unwrap() - 32 - mem::size_of::<u32>() * 2;
 
     let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -10,7 +10,6 @@
 use libc;
 use platform::{self, OsIpcChannel, OsIpcReceiverSet, OsIpcSender, OsIpcOneShotServer};
 use platform::{OsIpcSharedMemory};
-use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::thread;
@@ -174,30 +173,103 @@ fn big_data_with_sender_transfer() {
     thread.join().unwrap();
 }
 
-#[test]
-// This test only applies to platforms that need fragmentation.
-#[cfg(target_os="linux")]
-fn full_packet() {
-    let (tx, rx) = platform::channel().unwrap();
-
-    // Should be the biggest size that just fits in a single packet.
-    //
-    // 32 is the empirical size reseved by the kernel;
-    // the rest is for the fragment header.
-    //
-    // Note that this calculation might become imprecise
-    // when certain implementation details of the send() method change...
-    let size = tx.get_system_sendbuf_size().unwrap() - 32 - mem::size_of::<u32>() * 2;
+fn with_n_fds(n: usize, size: usize) {
+    let (sender_fds, receivers): (Vec<_>, Vec<_>) = (0..n).map(|_| platform::channel().unwrap())
+                                                    .map(|(tx, rx)| (OsIpcChannel::Sender(tx), rx))
+                                                    .unzip();
+    let (super_tx, super_rx) = platform::channel().unwrap();
 
     let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-    let data: &[u8] = &data[..];
-
-    tx.send(data, vec![], vec![]).unwrap();
+    super_tx.send(&data[..], sender_fds, vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
-        rx.recv().unwrap();
+        super_rx.recv().unwrap();
+
     received_data.truncate(size);
-    assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
-               (&data[..], vec![], vec![]));
+    assert_eq!(received_data.len(), data.len());
+    assert_eq!(&received_data[..], &data[..]);
+    assert_eq!(received_channels.len(), receivers.len());
+    assert_eq!(received_shared_memory_regions.len(), 0);
+
+    let data: Vec<u8> = (0..65536).map(|i| (i % 251) as u8).collect();
+    for (mut sender_fd, sub_rx) in received_channels.into_iter().zip(receivers.into_iter()) {
+        let sub_tx = sender_fd.to_sender();
+        sub_tx.send(&data[..], vec![], vec![]).unwrap();
+        let (mut received_data, received_channels, received_shared_memory_regions) =
+            sub_rx.recv().unwrap();
+        received_data.truncate(65536);
+        assert_eq!(received_data.len(), data.len());
+        assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
+                   (&data[..], vec![], vec![]));
+    }
+}
+
+// These tests only apply to platforms that need fragmentation.
+#[cfg(target_os="linux")]
+mod fragment_tests {
+    use platform;
+    use std::mem;
+    use super::with_n_fds;
+
+    lazy_static! {
+        static ref FRAGMENT_SIZE: usize = {
+            // Should be the biggest size that just fits in a single packet.
+            //
+            // 32 is the empirical size reseved by the kernel;
+            // the rest is for the fragment header.
+            //
+            // Note that this calculation might become imprecise
+            // when certain implementation details of the send() method change...
+            platform::channel().and_then(|(tx, _)| tx.get_system_sendbuf_size()).unwrap()
+                - 32 - mem::size_of::<u32>() * 2
+        };
+    }
+
+    #[test]
+    fn full_packet() {
+        with_n_fds(0, *FRAGMENT_SIZE);
+    }
+
+    #[test]
+    fn full_packet_with_1_fds() {
+        with_n_fds(1, *FRAGMENT_SIZE);
+    }
+    #[test]
+    fn full_packet_with_2_fds() {
+        with_n_fds(2, *FRAGMENT_SIZE);
+    }
+    #[test]
+    fn full_packet_with_3_fds() {
+        with_n_fds(3, *FRAGMENT_SIZE);
+    }
+    #[test]
+    fn full_packet_with_4_fds() {
+        with_n_fds(4, *FRAGMENT_SIZE);
+    }
+    #[test]
+    fn full_packet_with_5_fds() {
+        with_n_fds(5, *FRAGMENT_SIZE);
+    }
+    #[test]
+    fn full_packet_with_6_fds() {
+        with_n_fds(6, *FRAGMENT_SIZE);
+    }
+
+    // MAX_FDS_IN_CMSG is currently 64.
+    #[test]
+    fn full_packet_with_64_fds() {
+        with_n_fds(64, *FRAGMENT_SIZE);
+    }
+
+    #[test]
+    fn overfull_packet() {
+        with_n_fds(0, *FRAGMENT_SIZE + 1);
+    }
+
+    // In fragmented transfers, one FD is used up for the dedicated channel.
+    #[test]
+    fn overfull_packet_with_63_fds() {
+        with_n_fds(63, *FRAGMENT_SIZE + 1);
+    }
 }
 
 macro_rules! create_big_data_with_n_fds {

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -207,20 +207,11 @@ fn with_n_fds(n: usize, size: usize) {
 #[cfg(target_os="linux")]
 mod fragment_tests {
     use platform;
-    use std::mem;
     use super::with_n_fds;
 
     lazy_static! {
         static ref FRAGMENT_SIZE: usize = {
-            // Should be the biggest size that just fits in a single packet.
-            //
-            // 32 is the empirical size reseved by the kernel;
-            // the rest is for the fragment header.
-            //
-            // Note that this calculation might become imprecise
-            // when certain implementation details of the send() method change...
-            platform::channel().and_then(|(tx, _)| tx.get_system_sendbuf_size()).unwrap()
-                - 32 - mem::size_of::<u32>() * 2
+            platform::channel().and_then(|(tx, _)| tx.get_max_fragment_size()).unwrap()
         };
     }
 

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -211,7 +211,7 @@ mod fragment_tests {
 
     lazy_static! {
         static ref FRAGMENT_SIZE: usize = {
-            platform::channel().and_then(|(tx, _)| tx.get_max_fragment_size()).unwrap()
+            platform::OsIpcSender::get_max_fragment_size()
         };
     }
 


### PR DESCRIPTION
This is a bunch of optimisations to the Linux platform code, along with various cleanups of the related code which the optimisation patches build upon.

Most of the cleanups are on the `send()` side, as the `recv()` side is less affected by the optimisation changes, and thus there has been less reason to refactor the code -- some extra cleanup work would probably be in order here.

The optimisations are mostly about avoiding unnecessary copies by using scatter-gather buffers for send and receive; as well as avoiding unnecessary initialisation of receive buffers.

The results are impressive: with gains of at least 5x for large transfers of several MiB (a bit more on a modern system); >5x (on an old system) up to >10x (on a modern one) for small transfers of up to a few KiB; and more than 10x for most of the range in between -- peaking at about 12x - 13x on the old system and 20x - 21x on the modern system for medium-sized transfers of about 64 KiB up to a few hundred KiB.

For another interesting data point, the CPU usage during benchmark runs (with many iterations, to amortise the setup time) was dominated by user time (more than two thirds of total time) with the original variant; whereas the optimised variant not only further reduces system time to less then half the original value (presumably because of fewer allocations?), but also almost entirely eliminates the user time, making it pretty insignificant in the total picture now -- as it should be.

On a less scientific note, Servo built with the optimised ipc-channel doesn't seem to show undue delays any more while rendering a language selection menu. (Which requires lots of fonts to be loaded, and thus triggers heavy ipc-channel activity.)