### PR TITLE
Linux: Always retry with an actually smaller size on `ENOBUFS`

### DIFF
--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -277,6 +277,10 @@ impl UnixSender {
         fn downsize(sendbuf_size: &mut usize, sent_size: usize) -> Result<(),()> {
             if sent_size > 2000 {
                 *sendbuf_size /= 2;
+                // Make certain we end up with less than what we tried before...
+                if !(*sendbuf_size < sent_size) {
+                    *sendbuf_size = sent_size / 2;
+                }
                 Ok(())
             } else {
                 Err(())


### PR DESCRIPTION
Previously, if we got `ENOBUFS` while the packet we tried to send was
already less than half the maximum send buffer size, we would end up
with a new buffer size that was still larger than the actual packet...

Aside from being nonsensical, this would actually result in buggy
behaviour if the message was smaller than half the buffer size to begin
with, as the fragmented send code works from the assumption that the
message is larger than the fragment size, and will fail otherwise.

(In my testing, I never actually got `ENOBUFS` with packets smaller than
half the maximum buffer size -- but let's assume we might...)