### PR TITLE
Put file descriptors in an Arc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.2.2"
+version = "0.2.3"
 
 [lib]
 name = "ipc_channel"


### PR DESCRIPTION
We used to do this manually in servo, but @izgzhen turned it off when consolidating the resource senders

There really isn't much of a reason to not do this; and `mpsc::Sender` does this already (for a different reason)

r? @antrik or @pcwalton

cc @asajeffrey