### PR TITLE
platform/tests: cleanup: drop `truncate()` calls on received data

### DIFF
--- a/platform/macos/mod.rs
+++ b/platform/macos/mod.rs
@@ -808,17 +808,10 @@ struct Message {
 
 impl Message {
     fn size_of(data_length: usize, port_length: usize, shared_memory_length: usize) -> usize {
-        let mut size = mem::size_of::<Message>() +
+        mem::size_of::<Message>() +
             mem::size_of::<mach_msg_port_descriptor_t>() * port_length +
             mem::size_of::<mach_msg_ool_descriptor_t>() * shared_memory_length +
-            data_length;
-
-        // Round up to the next 4 bytes.
-        if (size & 0x3) != 0 {
-            size = (size & !0x3) + 4;
-        }
-
-        size
+            data_length
     }
 }
 

--- a/platform/test.rs
+++ b/platform/test.rs
@@ -23,7 +23,6 @@ fn simple() {
     let data: &[u8] = b"1234567";
     tx.send(data, Vec::new(), Vec::new()).unwrap();
     let (mut received_data, received_channels, received_shared_memory) = rx.recv().unwrap();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels, received_shared_memory),
                (data, Vec::new(), Vec::new()));
 }
@@ -40,7 +39,6 @@ fn sender_transfer() {
     sub_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(3);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -57,7 +55,6 @@ fn receiver_transfer() {
     sub_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(3);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -78,7 +75,6 @@ fn multisender_transfer() {
     sub0_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_subchannels, received_shared_memory_regions) =
         sub0_rx.recv().unwrap();
-    received_data.truncate(8);
     assert_eq!((&received_data[..], received_subchannels, received_shared_memory_regions),
                (data, vec![], vec![]));
 
@@ -86,7 +82,6 @@ fn multisender_transfer() {
     sub1_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_subchannels, received_shared_memory_regions) =
         sub1_rx.recv().unwrap();
-    received_data.truncate(8);
     assert_eq!((&received_data[..], received_subchannels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -99,7 +94,6 @@ fn medium_data() {
     tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
         rx.recv().unwrap();
-    received_data.truncate(65536);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
 }
@@ -117,7 +111,6 @@ fn medium_data_with_sender_transfer() {
     sub_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(65536);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -134,7 +127,6 @@ fn big_data() {
         rx.recv().unwrap();
     let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
-    received_data.truncate(1024 * 1024);
     assert_eq!(received_data.len(), data.len());
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
@@ -154,7 +146,6 @@ fn big_data_with_sender_transfer() {
         super_rx.recv().unwrap();
     let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
-    received_data.truncate(1024 * 1024);
     assert_eq!(received_data.len(), data.len());
     assert_eq!(&received_data[..], &data[..]);
     assert_eq!(received_channels.len(), 1);
@@ -166,7 +157,6 @@ fn big_data_with_sender_transfer() {
     sub_tx.send(data, vec![], vec![]).unwrap();
     let (mut received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(65536);
     assert_eq!(received_data.len(), data.len());
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
@@ -184,7 +174,6 @@ fn with_n_fds(n: usize, size: usize) {
     let (mut received_data, received_channels, received_shared_memory_regions) =
         super_rx.recv().unwrap();
 
-    received_data.truncate(size);
     assert_eq!(received_data.len(), data.len());
     assert_eq!(&received_data[..], &data[..]);
     assert_eq!(received_channels.len(), receivers.len());
@@ -196,7 +185,6 @@ fn with_n_fds(n: usize, size: usize) {
         sub_tx.send(&data[..], vec![], vec![]).unwrap();
         let (mut received_data, received_channels, received_shared_memory_regions) =
             sub_rx.recv().unwrap();
-        received_data.truncate(65536);
         assert_eq!(received_data.len(), data.len());
         assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                    (&data[..], vec![], vec![]));
@@ -282,7 +270,6 @@ macro_rules! create_big_data_with_n_fds {
 
             let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
             let data: &[u8] = &data[..];
-            received_data.truncate(1024 * 1024);
             assert_eq!(received_data.len(), data.len());
             assert_eq!(&received_data[..], &data[..]);
             assert_eq!(received_channels.len(), receivers.len());
@@ -295,7 +282,6 @@ macro_rules! create_big_data_with_n_fds {
                 sub_tx.send(data, vec![], vec![]).unwrap();
                 let (mut received_data, received_channels, received_shared_memory_regions) =
                     sub_rx.recv().unwrap();
-                received_data.truncate(65536);
                 assert_eq!(received_data.len(), data.len());
                 assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                            (&data[..], vec![], vec![]));
@@ -335,7 +321,6 @@ fn concurrent_senders() {
         received_vals.push(val);
         let data: Vec<u8> = (0.. 1024 * 1024).map(|j| (j % 13) as u8 | val << 4).collect();
         let data: &[u8] = &data[..];
-        received_data.truncate(1024 * 1024);
         assert_eq!(received_data.len(), data.len());
         assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                    (&data[..], vec![], vec![]));
@@ -361,14 +346,12 @@ fn receiver_set() {
     tx0.send(data, vec![], vec![]).unwrap();
     let (received_id, mut received_data, _, _) =
         rx_set.select().unwrap().into_iter().next().unwrap().unwrap();
-    received_data.truncate(7);
     assert_eq!(received_id, rx0_id);
     assert_eq!(received_data, data);
 
     tx1.send(data, vec![], vec![]).unwrap();
     let (received_id, mut received_data, _, _) =
         rx_set.select().unwrap().into_iter().next().unwrap().unwrap();
-    received_data.truncate(7);
     assert_eq!(received_id, rx1_id);
     assert_eq!(received_data, data);
 
@@ -378,7 +361,6 @@ fn receiver_set() {
     while !received0 || !received1 {
         for result in rx_set.select().unwrap().into_iter() {
             let (received_id, mut received_data, _, _) = result.unwrap();
-            received_data.truncate(7);
             assert_eq!(received_data, data);
             assert!(received_id == rx0_id || received_id == rx1_id);
             if received_id == rx0_id {
@@ -406,7 +388,6 @@ fn server() {
 
     let (_, mut received_data, received_channels, received_shared_memory_regions) =
         server.accept().unwrap();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -427,7 +408,6 @@ fn cross_process() {
     let (_, mut received_data, received_channels, received_shared_memory_regions) =
         server.accept().unwrap();
     child_pid.wait();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -459,7 +439,6 @@ fn cross_process_sender_transfer() {
     let (mut received_data, received_channels, received_shared_memory_regions) =
         super_rx.recv().unwrap();
     child_pid.wait();
-    received_data.truncate(3);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -480,7 +459,6 @@ fn shared_memory() {
     let shmem_data = OsIpcSharedMemory::from_byte(0xba, 1024 * 1024);
     tx.send(data, vec![], vec![shmem_data]).unwrap();
     let (mut received_data, received_channels, received_shared_memory) = rx.recv().unwrap();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels), (data, Vec::new()));
     assert_eq!(received_shared_memory[0].len(), 1024 * 1024);
     assert!(received_shared_memory[0].iter().all(|byte| *byte == 0xba));
@@ -500,7 +478,6 @@ fn try_recv() {
     let data: &[u8] = b"1234567";
     tx.send(data, Vec::new(), Vec::new()).unwrap();
     let (mut received_data, received_channels, received_shared_memory) = rx.try_recv().unwrap();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels, received_shared_memory),
                (data, Vec::new(), Vec::new()));
     assert!(rx.try_recv().is_err());
@@ -527,7 +504,6 @@ fn try_recv_large() {
 
     let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
-    received_data.truncate(1024 * 1024);
     assert_eq!((&received_data[..], received_channels, received_shared_memory),
                (data, vec![], vec![]));
     assert!(rx.try_recv().is_err());
@@ -590,7 +566,6 @@ fn try_recv_large_delayed() {
             result.is_err()
         } {}
         let (mut received_data, received_channels, received_shared_memory) = result.unwrap();
-        received_data.truncate(msg_size);
 
         let val = received_data[0] >> 4;
         received_vals.push(val);

--- a/test.rs
+++ b/test.rs
@@ -437,7 +437,7 @@ fn multiple_paths_to_a_sender() {
 
 #[test]
 fn bytes() {
-    let bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+    let bytes = [1, 2, 3, 4, 5, 6, 7];
     let (tx, rx) = ipc::bytes_channel().unwrap();
     tx.send(&bytes[..]).unwrap();
     let received_bytes = rx.recv().unwrap();
@@ -450,7 +450,7 @@ fn embedded_bytes_receivers() {
     let (super_tx, super_rx) = ipc::channel().unwrap();
     super_tx.send(sub_tx).unwrap();
     let sub_tx = super_rx.recv().unwrap();
-    let bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+    let bytes = [1, 2, 3, 4, 5, 6, 7];
     sub_tx.send(&bytes[..]).unwrap();
     let received_bytes = sub_rx.recv().unwrap();
     assert_eq!(&bytes, &received_bytes[..]);


### PR DESCRIPTION
I really can't think of any purpose these might serve...