### PR TITLE
Fix IpcOneShotServer for `inprocess` backend

### DIFF
--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -139,7 +139,7 @@ impl OsIpcSender {
     }
 
     pub fn connect(name: String) -> Result<OsIpcSender,MpscError> {
-        let record = ONE_SHOT_SERVERS.lock().unwrap().remove(&name).unwrap();
+        let record = ONE_SHOT_SERVERS.lock().unwrap().get(&name).unwrap().clone();
         record.connect();
         Ok(record.sender)
     }
@@ -285,6 +285,7 @@ impl OsIpcOneShotServer {
     {
         let record = ONE_SHOT_SERVERS.lock().unwrap().get(&self.name).unwrap().clone();
         record.accept();
+        ONE_SHOT_SERVERS.lock().unwrap().remove(&self.name).unwrap();
         let receiver = self.receiver.borrow_mut().take().unwrap();
         let (data, channels, shmems) = receiver.recv().unwrap();
         Ok((receiver, data, channels, shmems))

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -22,10 +22,11 @@ use std::usize;
 
 use uuid::Uuid;
 
+#[derive(Clone)]
 struct ServerRecord {
     sender: OsIpcSender,
     conn_sender: mpsc::Sender<bool>,
-    conn_receiver: Mutex<mpsc::Receiver<bool>>,
+    conn_receiver: Arc<Mutex<mpsc::Receiver<bool>>>,
 }
 
 impl ServerRecord {
@@ -34,7 +35,7 @@ impl ServerRecord {
         ServerRecord {
             sender: sender,
             conn_sender: tx,
-            conn_receiver: Mutex::new(rx),
+            conn_receiver: Arc::new(Mutex::new(rx)),
         }
     }
 
@@ -282,7 +283,8 @@ impl OsIpcOneShotServer {
                                     Vec<OsOpaqueIpcChannel>,
                                     Vec<OsIpcSharedMemory>),MpscError>
     {
-        ONE_SHOT_SERVERS.lock().unwrap().get(&self.name).unwrap().accept();
+        let record = ONE_SHOT_SERVERS.lock().unwrap().get(&self.name).unwrap().clone();
+        record.accept();
         let receiver = self.receiver.borrow_mut().take().unwrap();
         let (data, channels, shmems) = receiver.recv().unwrap();
         Ok((receiver, data, channels, shmems))

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -393,7 +393,25 @@ fn receiver_set() {
 }
 
 #[test]
-fn server() {
+fn server_accept_first() {
+    let (server, name) = OsIpcOneShotServer::new().unwrap();
+    let data: &[u8] = b"1234567";
+
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(30));
+        let tx = OsIpcSender::connect(name).unwrap();
+        tx.send(data, vec![], vec![]).unwrap();
+    });
+
+    let (_, mut received_data, received_channels, received_shared_memory_regions) =
+        server.accept().unwrap();
+    received_data.truncate(7);
+    assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
+               (data, vec![], vec![]));
+}
+
+#[test]
+fn server_connect_first() {
     let (server, name) = OsIpcOneShotServer::new().unwrap();
     let data: &[u8] = b"1234567";
 
@@ -402,6 +420,7 @@ fn server() {
         tx.send(data, vec![], vec![]).unwrap();
     });
 
+    thread::sleep(Duration::from_millis(30));
     let (_, mut received_data, received_channels, received_shared_memory_regions) =
         server.accept().unwrap();
     received_data.truncate(7);

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -393,8 +393,6 @@ fn receiver_set() {
 }
 
 #[test]
-//XXXjdm This hangs indefinitely on appveyor and warrants further investigation.
-#[cfg(not(windows))]
 fn server() {
     let (server, name) = OsIpcOneShotServer::new().unwrap();
     let data: &[u8] = b"1234567";


### PR DESCRIPTION
Several patches covering individual aspects, each fixing one possible situation that was broken.

(I don't think there was actually *any* situation that was working correctly before...)