### PR TITLE
Close the fd that we're removing from the pollfds list

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -439,6 +439,9 @@ impl OsIpcReceiverSet {
                     }
                     Err(err) if err.channel_is_closed() => {
                         hangups.insert(pollfd.fd);
+                        unsafe {
+                            libc::close(pollfd.fd);
+                        }
                         selection_results.push(OsIpcSelectionResult::ChannelClosed(
                                     pollfd.fd as i64))
                     }


### PR DESCRIPTION
We currently dup the file descriptor in add() by calling consume_fd(). We never close this dup'd fd. We should close it when we remove it from the pollfds list.
