### PR TITLE
Use autoincrementing number for handler ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ libc = "0.2.12"
 rand = "0.3"
 serde = "0.8"
 uuid = {version = "0.3", features = ["v4"]}
+fnv = "1.0.3"
 
 [dev-dependencies]
 crossbeam = "0.2"

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -211,12 +211,12 @@ impl IpcReceiverSet {
         })
     }
 
-    pub fn add<T>(&mut self, receiver: IpcReceiver<T>) -> Result<i64,Error>
+    pub fn add<T>(&mut self, receiver: IpcReceiver<T>) -> Result<u64,Error>
                   where T: Deserialize + Serialize {
         Ok(try!(self.os_receiver_set.add(receiver.os_receiver)))
     }
 
-    pub fn add_opaque(&mut self, receiver: OpaqueIpcReceiver) -> Result<i64,Error> {
+    pub fn add_opaque(&mut self, receiver: OpaqueIpcReceiver) -> Result<u64,Error> {
         Ok(try!(self.os_receiver_set.add(receiver.os_receiver)))
     }
 
@@ -307,12 +307,12 @@ impl IpcSharedMemory {
 }
 
 pub enum IpcSelectionResult {
-    MessageReceived(i64, OpaqueIpcMessage),
-    ChannelClosed(i64),
+    MessageReceived(u64, OpaqueIpcMessage),
+    ChannelClosed(u64),
 }
 
 impl IpcSelectionResult {
-    pub fn unwrap(self) -> (i64, OpaqueIpcMessage) {
+    pub fn unwrap(self) -> (u64, OpaqueIpcMessage) {
         match self {
             IpcSelectionResult::MessageReceived(id, message) => (id, message),
             IpcSelectionResult::ChannelClosed(id) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ extern crate rand;
 extern crate serde;
 #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
 extern crate uuid;
+#[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "freebsd")))]
+extern crate fnv;
 
 pub mod ipc;
 pub mod platform;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,6 +8,25 @@
 // except according to those terms.
 
 mod os {
+    #[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
+    struct Incrementor {
+        last_value: u64,
+    }
+
+    #[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
+    impl Incrementor {
+        fn new() -> Incrementor {
+            Incrementor {
+                last_value: 0
+            }
+        }
+
+        fn increment(&mut self) -> u64 {
+            self.last_value += 1;
+            self.last_value
+        }
+    }
+
     #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                     target_os = "freebsd")))]
     include!("unix/mod.rs");

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -7,15 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use fnv::FnvHasher;
 use bincode::serde::DeserializeError;
 use libc::{self, MAP_FAILED, MAP_SHARED, POLLIN, PROT_READ, PROT_WRITE, SOCK_SEQPACKET, SOL_SOCKET};
 use libc::{SO_LINGER, S_IFMT, S_IFSOCK, c_char, c_int, c_void, getsockopt};
 use libc::{iovec, mkstemp, mode_t, msghdr, nfds_t, off_t, poll, pollfd, recvmsg, sendmsg};
 use libc::{setsockopt, size_t, sockaddr, sockaddr_un, socketpair, socklen_t, sa_family_t};
 use std::cmp;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, CString};
 use std::fmt::{self, Debug, Formatter};
+use std::hash::BuildHasherDefault;
 use std::io::Error;
 use std::mem;
 use std::ops::Deref;
@@ -404,7 +406,9 @@ impl OsIpcChannel {
 }
 
 pub struct OsIpcReceiverSet {
+    incrementor: Incrementor,
     pollfds: Vec<pollfd>,
+    fdids: HashMap<c_int, u64, BuildHasherDefault<FnvHasher>>
 }
 
 impl Drop for OsIpcReceiverSet {
@@ -420,19 +424,24 @@ impl Drop for OsIpcReceiverSet {
 
 impl OsIpcReceiverSet {
     pub fn new() -> Result<OsIpcReceiverSet,UnixError> {
+        let fnv = BuildHasherDefault::<FnvHasher>::default();
         Ok(OsIpcReceiverSet {
+            incrementor: Incrementor::new(),
             pollfds: Vec::new(),
+            fdids: HashMap::with_hasher(fnv)
         })
     }
 
-    pub fn add(&mut self, receiver: OsIpcReceiver) -> Result<i64,UnixError> {
+    pub fn add(&mut self, receiver: OsIpcReceiver) -> Result<u64,UnixError> {
+        let last_index = self.incrementor.increment();
         let fd = receiver.consume_fd();
         self.pollfds.push(pollfd {
             fd: fd,
             events: POLLIN,
             revents: 0,
         });
-        Ok(fd as i64)
+        self.fdids.insert(fd, last_index);
+        Ok(last_index)
     }
 
     pub fn select(&mut self) -> Result<Vec<OsIpcSelectionResult>,UnixError> {
@@ -450,7 +459,7 @@ impl OsIpcReceiverSet {
                 match recv(pollfd.fd, BlockingMode::Blocking) {
                     Ok((data, channels, shared_memory_regions)) => {
                         selection_results.push(OsIpcSelectionResult::DataReceived(
-                                pollfd.fd as i64,
+                                *self.fdids.get(&pollfd.fd).unwrap(),
                                 data,
                                 channels,
                                 shared_memory_regions));
@@ -458,7 +467,7 @@ impl OsIpcReceiverSet {
                     Err(err) if err.channel_is_closed() => {
                         hangups.insert(pollfd.fd);
                         selection_results.push(OsIpcSelectionResult::ChannelClosed(
-                                    pollfd.fd as i64))
+                                    *self.fdids.get(&pollfd.fd).unwrap()))
                     }
                     Err(err) => return Err(err),
                 }
@@ -475,12 +484,12 @@ impl OsIpcReceiverSet {
 }
 
 pub enum OsIpcSelectionResult {
-    DataReceived(i64, Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>),
-    ChannelClosed(i64),
+    DataReceived(u64, Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>),
+    ChannelClosed(u64),
 }
 
 impl OsIpcSelectionResult {
-    pub fn unwrap(self) -> (i64, Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>) {
+    pub fn unwrap(self) -> (u64, Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>) {
         match self {
             OsIpcSelectionResult::DataReceived(id, data, channels, shared_memory_regions) => {
                 (id, data, channels, shared_memory_regions)

--- a/src/router.rs
+++ b/src/router.rs
@@ -77,9 +77,9 @@ struct RouterProxyComm {
 
 struct Router {
     msg_receiver: Receiver<RouterMsg>,
-    msg_wakeup_id: i64,
+    msg_wakeup_id: u64,
     ipc_receiver_set: IpcReceiverSet,
-    handlers: HashMap<i64,RouterHandler>,
+    handlers: HashMap<u64,RouterHandler>,
 }
 
 impl Router {


### PR DESCRIPTION
Use `Uuid` instead of `i64` for the handler keys to ensure file descriptor number reuse doesn't cause errors, and make sure to close file descriptors.

**NB:** The scope of the PR has changed to change the handler id's from a platform specific `i64` to an autoincrementing `u64`. `macos` has not yet been ported, and probably suffers from the same leak as the `unix` module did prior to this PR