### PR TITLE
Cleanup: Derive `Debug` on `OsIpcSender` instead of manual `impl`

### DIFF
--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -59,6 +59,7 @@ pub fn channel() -> Result<(OsIpcSender, OsIpcReceiver),MpscError> {
     Ok((OsIpcSender::new(base_sender), OsIpcReceiver::new(base_receiver)))
 }
 
+#[derive(Debug)]
 pub struct OsIpcReceiver {
     receiver: RefCell<Option<mpsc::Receiver<MpscChannelMessage>>>,
 }
@@ -67,14 +68,6 @@ impl PartialEq for OsIpcReceiver {
     fn eq(&self, other: &OsIpcReceiver) -> bool {
         self.receiver.borrow().as_ref().map(|rx| rx as *const _) ==
             other.receiver.borrow().as_ref().map(|rx| rx as *const _)
-    }
-}
-
-// Can't derive, as mpsc::Receiver doesn't implement Debug.
-impl fmt::Debug for OsIpcReceiver {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Not sure there is anything useful we could print here.
-        write!(f, "OsIpcReceiver {{ .. }}")
     }
 }
 


### PR DESCRIPTION
The `Debug` implementation for `mpsc` has been upstream for quite a long
time now -- so we can just derive one for `OsIpcSender` now.

While the internal details the derived implementation will print may not
be terribly useful, they shouldn't really hurt either; and this removes
some lines of boilerplate code, so I consider it a win.