### PR TITLE
Cleanup: Derive `Debug` on `OsIpcReceiver` as well

### DIFF
--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -104,7 +104,7 @@ impl OsIpcReceiver {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct OsIpcSender {
     sender: Arc<Mutex<mpsc::Sender<MpscChannelMessage>>>,
 }
@@ -113,14 +113,6 @@ impl PartialEq for OsIpcSender {
     fn eq(&self, other: &OsIpcSender) -> bool {
         &*self.sender.lock().unwrap() as *const _ ==
             &*other.sender.lock().unwrap() as *const _
-    }
-}
-
-// Can't derive, as mpsc::Sender doesn't implement Debug.
-impl fmt::Debug for OsIpcSender {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Not sure there is anything useful we could print here.
-        write!(f, "OsIpcSender {{ .. }}")
     }
 }
 


### PR DESCRIPTION
Followup on 359077a4085ca952db826a36e1b58c20a25aedcb -- I missed the
corresponding implementation for `OsIpcReceiver` while replacing the
manual `Debug` implementation on `OsIpcSender`.