### PR TITLE
Don't make `OsIpcSender` `Sync`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ os:
   - osx
 
 env:
-  - FEATURES=""
-  - FEATURES="--features force-inprocess"
+  - FEATURES="unstable"
+  - FEATURES="unstable force-inprocess"
 
 notifications:
   webhooks: http://build.servo.org:54856/travis
 
 script:
-  - cargo build $FEATURES
-  - cargo test $FEATURES
+  - cargo build --features "$FEATURES"
+  - cargo test --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/servo/ipc-channel"
 
 [features]
 force-inprocess = []
+unstable = []
 
 [dependencies]
 bincode = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.5.1"
+version = "0.6.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,4 @@ install:
 build: false
 
 test_script:
-  - cargo test --verbose
+  - 'cargo test --verbose --features "unstable"'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![cfg_attr(any(feature = "force-inprocess", target_os = "windows", target_os = "android"),
 			feature(mpsc_select))]
+#![cfg_attr(all(feature = "unstable", test), feature(specialization))]
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -106,20 +106,20 @@ impl OsIpcReceiver {
 
 #[derive(Clone, Debug)]
 pub struct OsIpcSender {
-    sender: Arc<Mutex<mpsc::Sender<MpscChannelMessage>>>,
+    sender: RefCell<mpsc::Sender<MpscChannelMessage>>,
 }
 
 impl PartialEq for OsIpcSender {
     fn eq(&self, other: &OsIpcSender) -> bool {
-        &*self.sender.lock().unwrap() as *const _ ==
-            &*other.sender.lock().unwrap() as *const _
+        &*self.sender.borrow() as *const _ ==
+            &*other.sender.borrow() as *const _
     }
 }
 
 impl OsIpcSender {
     fn new(sender: mpsc::Sender<MpscChannelMessage>) -> OsIpcSender {
         OsIpcSender {
-            sender: Arc::new(Mutex::new(sender)),
+            sender: RefCell::new(sender),
         }
     }
 
@@ -139,7 +139,7 @@ impl OsIpcSender {
                 shared_memory_regions: Vec<OsIpcSharedMemory>)
                 -> Result<(),MpscError>
     {
-        match self.sender.lock().unwrap().send(MpscChannelMessage(data.to_vec(), ports, shared_memory_regions)) {
+        match self.sender.borrow().send(MpscChannelMessage(data.to_vec(), ports, shared_memory_regions)) {
             Err(_) => Err(MpscError::ChannelClosedError),
             Ok(_) => Ok(()),
         }

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -629,3 +629,27 @@ fn try_recv_large_delayed() {
         thread.join().unwrap();
     }
 }
+
+#[cfg(feature = "unstable")]
+mod sync_test {
+    use platform;
+
+    trait SyncTest {
+        fn test_not_sync();
+    }
+
+    impl<T> SyncTest for T {
+        default fn test_not_sync() {}
+    }
+
+    impl<T: Sync> SyncTest for T {
+        fn test_not_sync() {
+            panic!("`OsIpcSender` should not be `Sync`");
+        }
+    }
+
+    #[test]
+    fn receiver_not_sync() {
+        platform::OsIpcSender::test_not_sync();
+    }
+}


### PR DESCRIPTION
`mpsc::Sender` isn't `Sync` -- and the `ipc-channel` equivalent probably
shouldn't be either. Sharing references to senders is usually not a good
idea: they are rather meant to be cloned instead; and they implement
internal sharing to make this efficient and robust -- sharing references
to senders just adds an unnecessary extra layer of sharing on top.

For the `inprocess` back-end, implementing `Sync` was necessitating
use of an `Arc<Mutex<>>`, adding considerable overhead even when not
used -- so this change is an optimisation. It effectively reverts most
of the sender part of 30b2024 (the
receiver part was already backed out in
77469c2 ), except that it obviously
doesn't re-introduce the bogus explicit `Sync` claim.

For the `macos` and `unix` back-ends, the sender implementations were
inherently `Sync`; so we explicitly mark them `!Sync` now, to get a
consistent API.

Also bumping the `ipc-channel` version here, as this is a breaking
change.

(It affects Servo only in one place though, see https://github.com/servo/servo/pull/14048 )

This also comes with a test case to verify that `OsIpcSender` indeed isn't `Sync` any more; and a CI change to activate it.