### PR TITLE
macos: Cleanup: Remove no-op `match`

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -520,12 +520,7 @@ impl OsIpcReceiverSet {
     }
 
     pub fn select(&mut self) -> Result<Vec<OsIpcSelectionResult>,MachError> {
-        match select(self.port.get(), BlockingMode::Blocking).map(|result| vec![result]) {
-            Ok(results) => Ok(results),
-            Err(error) => {
-                Err(error)
-            }
-        }
+        select(self.port.get(), BlockingMode::Blocking).map(|result| vec![result])
     }
 }
 


### PR DESCRIPTION
This reverts a part of 49fae1e8b03e6969b195ec7efd8bcae5445ebd68 that
ended up in the commit by accident...