### PR TITLE
Retry macOS select operations instead of panicking

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -577,29 +577,32 @@ fn select(port: mach_port_t, blocking_mode: BlockingMode)
                                  timeout,
                                  MACH_PORT_NULL) {
             MACH_RCV_TOO_LARGE => {
-                // the actual size gets written into msgh_size by the kernel
-                let max_trailer_size = mem::size_of::<mach_sys::mach_msg_max_trailer_t>() as mach_sys::mach_msg_size_t;
-                let actual_size = (*message).header.msgh_size + max_trailer_size;
-                allocated_buffer = Some(libc::malloc(actual_size as size_t));
-                setup_receive_buffer(slice::from_raw_parts_mut(
-                                        allocated_buffer.unwrap() as *mut u8,
-                                        actual_size as usize),
-                                     port);
-                message = allocated_buffer.unwrap() as *mut Message;
-                match mach_sys::mach_msg(message as *mut _,
-                                         flags,
-                                         0,
-                                         actual_size,
-                                         port,
-                                         timeout,
-                                         MACH_PORT_NULL) {
-                    MACH_MSG_SUCCESS => {},
-                    MACH_RCV_TOO_LARGE => {
-                        panic!("message was bigger than we were told");
-                    }
-                    os_result => {
-                        libc::free(allocated_buffer.unwrap() as *mut _);
-                        return Err(MachError(os_result))
+                loop {
+                    // the actual size gets written into msgh_size by the kernel
+                    let max_trailer_size = mem::size_of::<mach_sys::mach_msg_max_trailer_t>() as mach_sys::mach_msg_size_t;
+                    let actual_size = (*message).header.msgh_size + max_trailer_size;
+                    allocated_buffer = Some(libc::malloc(actual_size as size_t));
+                    setup_receive_buffer(slice::from_raw_parts_mut(
+                                            allocated_buffer.unwrap() as *mut u8,
+                                            actual_size as usize),
+                                         port);
+                    message = allocated_buffer.unwrap() as *mut Message;
+                    match mach_sys::mach_msg(message as *mut _,
+                                             flags,
+                                             0,
+                                             actual_size,
+                                             port,
+                                             timeout,
+                                             MACH_PORT_NULL) {
+                        MACH_MSG_SUCCESS => break,
+                        MACH_RCV_TOO_LARGE => {
+                            libc::free(allocated_buffer.unwrap() as *mut _);
+                            continue;
+                        }
+                        os_result => {
+                            libc::free(allocated_buffer.unwrap() as *mut _);
+                            return Err(MachError(os_result))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#99 made the calculation for buffer sizes for receives work correctly, but there appears to be no guarantee that the size will remain the same when we retry. This can lead to a panic in the current code (as observed in https://github.com/servo/servo/pull/14146#issuecomment-259599900). The test passes if we retry the operation until it succeeds, which matches other code I've found in the wild like https://github.com/openmach/openmach/blob/a185c84f7f5052b7b9f5531ab3612aaf88d3802e/libmach/flick_mach3mig_client.c#L88 .