### PR TITLE
Benchmarks: wrap the IpcSender in a mutex

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -35,12 +35,13 @@ fn bench_size(b: &mut test::Bencher, size: usize) {
     let wait_rx = Mutex::new(wait_rx);
 
     if size > platform::OsIpcSender::get_max_fragment_size() {
+        let safe_tx = Mutex::new(tx);
         b.iter(|| {
             crossbeam::scope(|scope| {
                 scope.spawn(|| {
                     let wait_rx = wait_rx.lock().unwrap();
                     for _ in 0..ITERATIONS {
-                        tx.send(&data, vec![], vec![]).unwrap();
+                        safe_tx.lock().unwrap().send(&data, vec![], vec![]).unwrap();
                         if ITERATIONS > 1 {
                             // Prevent beginning of the next send
                             // from overlapping with receive of last fragment,


### PR DESCRIPTION
After e6ea8390f6f423d3c5def98cb1fdf936a6a2f2ac `IpcSenders` are not `Sync`
and therefore the implicit capture in the closure will cause compile
time failures. If the size is greater than the result of
`get_max_fragment_size` wrap the `IpcSender` in a `Mutex`.

This is what I used to get benchmarks working again for my tests of #94 

Fixes: #120 