### PR TITLE
Fix benchmarks with `OsIpcReceiver` not being `Sync` anymore

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -37,8 +37,10 @@ fn bench_size(b: &mut test::Bencher, size: usize) {
     if size > platform::OsIpcSender::get_max_fragment_size() {
         b.iter(|| {
             crossbeam::scope(|scope| {
+                let tx = tx.clone();
                 scope.spawn(|| {
                     let wait_rx = wait_rx.lock().unwrap();
+                    let tx = tx;
                     for _ in 0..ITERATIONS {
                         tx.send(&data, vec![], vec![]).unwrap();
                         if ITERATIONS > 1 {


### PR DESCRIPTION
The first commit is the minimal fix to get it working again.

The second patch switches to a different thread handling approach, which inexplicably produces lower overhead in some (unrelated) cases on my system...