### PR TITLE
Avoid unnecessary FD cloning

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -304,17 +304,35 @@ mod ipc {
             });
         }
 
-        #[bench]
         // Benchmark performance of removing closed receivers from set.
         // This also includes the time for adding receivers,
         // as there is no way to measure the removing in isolation.
-        fn add_and_remove_closed_receivers(b: &mut test::Bencher) -> () {
+        fn bench_remove_closed(b: &mut test::Bencher, n: usize) {
             b.iter(|| {
-                let mut rx_set = create_set_of_n(1);
-                // On `select()`, receivers with a "ClosedChannel" event will be closed,
-                // and automatically dropped from the set.
-                rx_set.select().unwrap();
+                let mut rx_set = create_set_of_n(n);
+
+                let mut dropped_count = 0;
+                while dropped_count < n {
+                    // On `select()`, receivers with a "ClosedChannel" event will be closed,
+                    // and automatically dropped from the set.
+                    dropped_count += rx_set.select().unwrap().len();
+                }
             });
+        }
+
+        #[bench]
+        fn add_and_remove_1_closed_receivers(b: &mut test::Bencher) {
+            bench_remove_closed(b, 1);
+        }
+
+        #[bench]
+        fn add_and_remove_10_closed_receivers(b: &mut test::Bencher) {
+            bench_remove_closed(b, 10);
+        }
+
+        #[bench]
+        fn add_and_remove_100_closed_receivers(b: &mut test::Bencher) {
+            bench_remove_closed(b, 100);
         }
     }
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -211,10 +211,6 @@ mod ipc {
             });
         }
 
-        fn create_empty_set() -> Result<IpcReceiverSet, ()> {
-            Ok(IpcReceiverSet::new().unwrap())
-        }
-
         fn add_n_rxs(rx_set: &mut IpcReceiverSet, n: usize) -> () {
             for _ in 0..n {
                 let (_, rx) = ipc::channel::<()>().unwrap();
@@ -279,7 +275,7 @@ mod ipc {
         #[bench]
         fn create_and_destroy_empty_set(b: &mut test::Bencher) -> () {
             b.iter(|| {
-                create_empty_set().unwrap();
+                IpcReceiverSet::new().unwrap();
             });
         }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -185,7 +185,7 @@ mod ipc {
 
         // Benchmark selecting over a set of `n` receivers,
         // with `to_send` of them actually having pending data.
-        fn gen_select_test(b: &mut test::Bencher, to_send: usize, n: usize) -> () {
+        fn bench_send_on_m_of_n(b: &mut test::Bencher, to_send: usize, n: usize) -> () {
             let mut active = Vec::with_capacity(to_send);
             let mut dormant = Vec::with_capacity(n - to_send);
             let mut rx_set = IpcReceiverSet::new().unwrap();
@@ -215,56 +215,56 @@ mod ipc {
 
         #[bench]
         fn send_on_1_of_1(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 1, 1);
+            bench_send_on_m_of_n(b, 1, 1);
         }
 
         #[bench]
         fn send_on_1_of_5(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 1, 5);
+            bench_send_on_m_of_n(b, 1, 5);
         }
 
         #[bench]
         fn send_on_2_of_5(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 2, 5);
+            bench_send_on_m_of_n(b, 2, 5);
         }
 
         #[bench]
         fn send_on_5_of_5(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 5, 5);
+            bench_send_on_m_of_n(b, 5, 5);
         }
 
         #[bench]
         fn send_on_1_of_20(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 1, 20);
+            bench_send_on_m_of_n(b, 1, 20);
         }
 
         #[bench]
         fn send_on_5_of_20(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 5, 20);
+            bench_send_on_m_of_n(b, 5, 20);
         }
 
         #[bench]
         fn send_on_20_of_20(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 20, 20);
+            bench_send_on_m_of_n(b, 20, 20);
         }
 
         #[bench]
         fn send_on_1_of_100(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 1, 100);
+            bench_send_on_m_of_n(b, 1, 100);
         }
 
         #[bench]
         fn send_on_5_of_100(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 5, 100);
+            bench_send_on_m_of_n(b, 5, 100);
         }
         #[bench]
         fn send_on_20_of_100(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 20, 100);
+            bench_send_on_m_of_n(b, 20, 100);
         }
 
         #[bench]
         fn send_on_100_of_100(b: &mut test::Bencher) -> () {
-            gen_select_test(b, 100, 100);
+            bench_send_on_m_of_n(b, 100, 100);
         }
 
         fn create_set_of_n(n: usize) -> IpcReceiverSet {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -183,6 +183,8 @@ mod ipc {
         use ipc_channel::ipc::{self, IpcReceiverSet};
         use test;
 
+        // Benchmark selecting over a set of `n` receivers,
+        // with `to_send` of them actually having pending data.
         fn gen_select_test(b: &mut test::Bencher, to_send: usize, n: usize) -> () {
             let mut active = Vec::with_capacity(to_send);
             let mut dormant = Vec::with_capacity(n - to_send);
@@ -303,12 +305,14 @@ mod ipc {
         }
 
         #[bench]
-        // Benchmark adding and removing closed receivers from the set
+        // Benchmark performance of removing closed receivers from set.
+        // This also includes the time for adding receivers,
+        // as there is no way to measure the removing in isolation.
         fn add_and_remove_closed_receivers(b: &mut test::Bencher) -> () {
             b.iter(|| {
                 let mut rx_set = create_set_of_n(1);
-                // On select Receivers with a "ClosedChannel" event
-                // will be closed
+                // On `select()`, receivers with a "ClosedChannel" event will be closed,
+                // and automatically dropped from the set.
                 rx_set.select().unwrap();
             });
         }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -310,8 +310,6 @@ mod ipc {
                 // On select Receivers with a "ClosedChannel" event
                 // will be closed
                 rx_set.select().unwrap();
-                let (_, rx) = ipc::channel::<()>().unwrap();
-                rx_set.add(rx).unwrap();
             });
         }
     }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -280,6 +280,14 @@ mod ipc {
         }
 
         #[bench]
+        fn create_and_destroy_set_of_1(b: &mut test::Bencher) -> () {
+            b.iter(|| {
+                let mut rx_set = IpcReceiverSet::new().unwrap();
+                add_n_rxs(&mut rx_set, 1);
+            });
+        }
+
+        #[bench]
         fn create_and_destroy_set_of_10(b: &mut test::Bencher) -> () {
             b.iter(|| {
                 let mut rx_set = IpcReceiverSet::new().unwrap();
@@ -288,10 +296,10 @@ mod ipc {
         }
 
         #[bench]
-        fn create_and_destroy_set_of_5(b: &mut test::Bencher) -> () {
+        fn create_and_destroy_set_of_100(b: &mut test::Bencher) -> () {
             b.iter(|| {
                 let mut rx_set = IpcReceiverSet::new().unwrap();
-                add_n_rxs(&mut rx_set, 5);
+                add_n_rxs(&mut rx_set, 100);
             });
         }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,12 +1,7 @@
 #![feature(test)]
 
-extern crate crossbeam;
 extern crate ipc_channel;
 extern crate test;
-
-use ipc_channel::platform;
-
-use std::sync::{mpsc, Mutex};
 
 /// Allows doing multiple inner iterations per bench.iter() run.
 ///
@@ -18,297 +13,309 @@ use std::sync::{mpsc, Mutex};
 /// as the benchmark framework doesn't know about the inner iterations...
 const ITERATIONS: usize = 1;
 
-#[bench]
-fn create_channel(b: &mut test::Bencher) {
-    b.iter(|| {
-        for _ in 0..ITERATIONS {
-            platform::channel().unwrap();
-        }
-    });
-}
+mod platform {
+    extern crate crossbeam;
 
-fn bench_size(b: &mut test::Bencher, size: usize) {
-    let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-    let (tx, rx) = platform::channel().unwrap();
+    use ipc_channel::platform;
+    use ITERATIONS;
 
-    let (wait_tx, wait_rx) = mpsc::channel();
-    let wait_rx = Mutex::new(wait_rx);
-
-    if size > platform::OsIpcSender::get_max_fragment_size() {
-        b.iter(|| {
-            crossbeam::scope(|scope| {
-                let tx = tx.clone();
-                scope.spawn(|| {
-                    let wait_rx = wait_rx.lock().unwrap();
-                    let tx = tx;
-                    for _ in 0..ITERATIONS {
-                        tx.send(&data, vec![], vec![]).unwrap();
-                        if ITERATIONS > 1 {
-                            // Prevent beginning of the next send
-                            // from overlapping with receive of last fragment,
-                            // as otherwise results of runs with a large tail fragment
-                            // are significantly skewed.
-                            wait_rx.recv().unwrap();
-                        }
-                    }
-                });
-                for _ in 0..ITERATIONS {
-                    rx.recv().unwrap();
-                    if ITERATIONS > 1 {
-                        wait_tx.send(()).unwrap();
-                    }
-                }
-                // For reasons mysterious to me,
-                // not returning a value *from every branch*
-                // adds some 100 ns or so of overhead to all results --
-                // which is quite significant for very short tests...
-                0
-            })
-        });
-    } else {
-        b.iter(|| {
-            for _ in 0..ITERATIONS {
-                tx.send(&data, vec![], vec![]).unwrap();
-                rx.recv().unwrap();
-            }
-            0
-        });
-    }
-}
-
-#[bench]
-fn size_00_1(b: &mut test::Bencher) {
-    bench_size(b, 1);
-}
-#[bench]
-fn size_01_2(b: &mut test::Bencher) {
-    bench_size(b, 2);
-}
-#[bench]
-fn size_02_4(b: &mut test::Bencher) {
-    bench_size(b, 4);
-}
-#[bench]
-fn size_03_8(b: &mut test::Bencher) {
-    bench_size(b, 8);
-}
-#[bench]
-fn size_04_16(b: &mut test::Bencher) {
-    bench_size(b, 16);
-}
-#[bench]
-fn size_05_32(b: &mut test::Bencher) {
-    bench_size(b, 32);
-}
-#[bench]
-fn size_06_64(b: &mut test::Bencher) {
-    bench_size(b, 64);
-}
-#[bench]
-fn size_07_128(b: &mut test::Bencher) {
-    bench_size(b, 128);
-}
-#[bench]
-fn size_08_256(b: &mut test::Bencher) {
-    bench_size(b, 256);
-}
-#[bench]
-fn size_09_512(b: &mut test::Bencher) {
-    bench_size(b, 512);
-}
-#[bench]
-fn size_10_1k(b: &mut test::Bencher) {
-    bench_size(b, 1 * 1024);
-}
-#[bench]
-fn size_11_2k(b: &mut test::Bencher) {
-    bench_size(b, 2 * 1024);
-}
-#[bench]
-fn size_12_4k(b: &mut test::Bencher) {
-    bench_size(b, 4 * 1024);
-}
-#[bench]
-fn size_13_8k(b: &mut test::Bencher) {
-    bench_size(b, 8 * 1024);
-}
-#[bench]
-fn size_14_16k(b: &mut test::Bencher) {
-    bench_size(b, 16 * 1024);
-}
-#[bench]
-fn size_15_32k(b: &mut test::Bencher) {
-    bench_size(b, 32 * 1024);
-}
-#[bench]
-fn size_16_64k(b: &mut test::Bencher) {
-    bench_size(b, 64 * 1024);
-}
-#[bench]
-fn size_17_128k(b: &mut test::Bencher) {
-    bench_size(b, 128 * 1024);
-}
-#[bench]
-fn size_18_256k(b: &mut test::Bencher) {
-    bench_size(b, 256 * 1024);
-}
-#[bench]
-fn size_19_512k(b: &mut test::Bencher) {
-    bench_size(b, 512 * 1024);
-}
-#[bench]
-fn size_20_1m(b: &mut test::Bencher) {
-    bench_size(b, 1 * 1024 * 1024);
-}
-#[bench]
-fn size_21_2m(b: &mut test::Bencher) {
-    bench_size(b, 2 * 1024 * 1024);
-}
-#[bench]
-fn size_22_4m(b: &mut test::Bencher) {
-    bench_size(b, 4 * 1024 * 1024);
-}
-#[bench]
-fn size_23_8m(b: &mut test::Bencher) {
-    bench_size(b, 8 * 1024 * 1024);
-}
-
-mod receiver_set {
-    use ipc_channel::ipc::{self, IpcReceiverSet};
+    use std::sync::{mpsc, Mutex};
     use test;
 
-    fn gen_select_test(b: &mut test::Bencher, to_send: usize, n: usize) -> () {
-        let mut active = Vec::with_capacity(to_send);
-        let mut dormant = Vec::with_capacity(n - to_send);
-        let mut rx_set = IpcReceiverSet::new().unwrap();
-        for _ in 0..to_send {
-            let (tx, rx) = ipc::channel().unwrap();
-            rx_set.add(rx).unwrap();
-            active.push(tx);
-        }
-        for _ in to_send..n {
-            let (tx, rx) = ipc::channel::<()>().unwrap();
-            rx_set.add(rx).unwrap();
-            dormant.push(tx);
-        }
+    #[bench]
+    fn create_channel(b: &mut test::Bencher) {
         b.iter(|| {
-            for tx in active.iter() {
-                tx.send(()).unwrap();
-            }
-            let mut received = 0;
-            while received < to_send {
-                for result in rx_set.select().unwrap().into_iter() {
-                    let (_, _) = result.unwrap();
-                    received += 1;
-                }
+            for _ in 0..ITERATIONS {
+                platform::channel().unwrap();
             }
         });
     }
 
-    fn create_empty_set() -> Result<IpcReceiverSet, ()> {
-        Ok(IpcReceiverSet::new().unwrap())
-    }
+    fn bench_transfer_data(b: &mut test::Bencher, size: usize) {
+        let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        let (tx, rx) = platform::channel().unwrap();
 
-    fn add_n_rxs(rx_set: &mut IpcReceiverSet, n: usize) -> () {
-        for _ in 0..n {
-            let (_, rx) = ipc::channel::<()>().unwrap();
-            rx_set.add(rx).unwrap();
+        let (wait_tx, wait_rx) = mpsc::channel();
+        let wait_rx = Mutex::new(wait_rx);
+
+        if size > platform::OsIpcSender::get_max_fragment_size() {
+            b.iter(|| {
+                crossbeam::scope(|scope| {
+                    let tx = tx.clone();
+                    scope.spawn(|| {
+                        let wait_rx = wait_rx.lock().unwrap();
+                        let tx = tx;
+                        for _ in 0..ITERATIONS {
+                            tx.send(&data, vec![], vec![]).unwrap();
+                            if ITERATIONS > 1 {
+                                // Prevent beginning of the next send
+                                // from overlapping with receive of last fragment,
+                                // as otherwise results of runs with a large tail fragment
+                                // are significantly skewed.
+                                wait_rx.recv().unwrap();
+                            }
+                        }
+                    });
+                    for _ in 0..ITERATIONS {
+                        rx.recv().unwrap();
+                        if ITERATIONS > 1 {
+                            wait_tx.send(()).unwrap();
+                        }
+                    }
+                    // For reasons mysterious to me,
+                    // not returning a value *from every branch*
+                    // adds some 100 ns or so of overhead to all results --
+                    // which is quite significant for very short tests...
+                    0
+                })
+            });
+        } else {
+            b.iter(|| {
+                for _ in 0..ITERATIONS {
+                    tx.send(&data, vec![], vec![]).unwrap();
+                    rx.recv().unwrap();
+                }
+                0
+            });
         }
     }
 
     #[bench]
-    fn send_on_1_of_1(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 1, 1);
+    fn transfer_data_00_1(b: &mut test::Bencher) {
+        bench_transfer_data(b, 1);
     }
+    #[bench]
+    fn transfer_data_01_2(b: &mut test::Bencher) {
+        bench_transfer_data(b, 2);
+    }
+    #[bench]
+    fn transfer_data_02_4(b: &mut test::Bencher) {
+        bench_transfer_data(b, 4);
+    }
+    #[bench]
+    fn transfer_data_03_8(b: &mut test::Bencher) {
+        bench_transfer_data(b, 8);
+    }
+    #[bench]
+    fn transfer_data_04_16(b: &mut test::Bencher) {
+        bench_transfer_data(b, 16);
+    }
+    #[bench]
+    fn transfer_data_05_32(b: &mut test::Bencher) {
+        bench_transfer_data(b, 32);
+    }
+    #[bench]
+    fn transfer_data_06_64(b: &mut test::Bencher) {
+        bench_transfer_data(b, 64);
+    }
+    #[bench]
+    fn transfer_data_07_128(b: &mut test::Bencher) {
+        bench_transfer_data(b, 128);
+    }
+    #[bench]
+    fn transfer_data_08_256(b: &mut test::Bencher) {
+        bench_transfer_data(b, 256);
+    }
+    #[bench]
+    fn transfer_data_09_512(b: &mut test::Bencher) {
+        bench_transfer_data(b, 512);
+    }
+    #[bench]
+    fn transfer_data_10_1k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 1 * 1024);
+    }
+    #[bench]
+    fn transfer_data_11_2k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 2 * 1024);
+    }
+    #[bench]
+    fn transfer_data_12_4k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 4 * 1024);
+    }
+    #[bench]
+    fn transfer_data_13_8k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 8 * 1024);
+    }
+    #[bench]
+    fn transfer_data_14_16k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 16 * 1024);
+    }
+    #[bench]
+    fn transfer_data_15_32k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 32 * 1024);
+    }
+    #[bench]
+    fn transfer_data_16_64k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 64 * 1024);
+    }
+    #[bench]
+    fn transfer_data_17_128k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 128 * 1024);
+    }
+    #[bench]
+    fn transfer_data_18_256k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 256 * 1024);
+    }
+    #[bench]
+    fn transfer_data_19_512k(b: &mut test::Bencher) {
+        bench_transfer_data(b, 512 * 1024);
+    }
+    #[bench]
+    fn transfer_data_20_1m(b: &mut test::Bencher) {
+        bench_transfer_data(b, 1 * 1024 * 1024);
+    }
+    #[bench]
+    fn transfer_data_21_2m(b: &mut test::Bencher) {
+        bench_transfer_data(b, 2 * 1024 * 1024);
+    }
+    #[bench]
+    fn transfer_data_22_4m(b: &mut test::Bencher) {
+        bench_transfer_data(b, 4 * 1024 * 1024);
+    }
+    #[bench]
+    fn transfer_data_23_8m(b: &mut test::Bencher) {
+        bench_transfer_data(b, 8 * 1024 * 1024);
+    }
+}
 
-    #[bench]
-    fn send_on_1_of_5(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 1, 5);
-    }
+mod ipc {
+    mod receiver_set {
+        use ipc_channel::ipc::{self, IpcReceiverSet};
+        use test;
 
-    #[bench]
-    fn send_on_2_of_5(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 2, 5);
-    }
-
-    #[bench]
-    fn send_on_5_of_5(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 5, 5);
-    }
-
-    #[bench]
-    fn send_on_1_of_20(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 1, 20);
-    }
-
-    #[bench]
-    fn send_on_5_of_20(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 5, 20);
-    }
-
-    #[bench]
-    fn send_on_20_of_20(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 20, 20);
-    }
-
-    #[bench]
-    fn send_on_1_of_100(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 1, 100);
-    }
-
-    #[bench]
-    fn send_on_5_of_100(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 5, 100);
-    }
-    #[bench]
-    fn send_on_20_of_100(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 20, 100);
-    }
-
-    #[bench]
-    fn send_on_100_of_100(b: &mut test::Bencher) -> () {
-        gen_select_test(b, 100, 100);
-    }
-
-    #[bench]
-    fn create_and_destroy_empty_set(b: &mut test::Bencher) -> () {
-        b.iter(|| {
-            create_empty_set().unwrap();
-        });
-    }
-
-    #[bench]
-    fn create_and_destroy_set_of_10(b: &mut test::Bencher) -> () {
-        b.iter(|| {
+        fn gen_select_test(b: &mut test::Bencher, to_send: usize, n: usize) -> () {
+            let mut active = Vec::with_capacity(to_send);
+            let mut dormant = Vec::with_capacity(n - to_send);
             let mut rx_set = IpcReceiverSet::new().unwrap();
-            add_n_rxs(&mut rx_set, 10);
-        });
-    }
-
-    #[bench]
-    fn create_and_destroy_set_of_5(b: &mut test::Bencher) -> () {
-        b.iter(|| {
-            let mut rx_set = IpcReceiverSet::new().unwrap();
-            add_n_rxs(&mut rx_set, 5);
-        });
-    }
-
-    #[bench]
-    // Benchmark adding and removing closed receivers from the set
-    fn add_and_remove_closed_receivers(b: &mut test::Bencher) -> () {
-        b.iter(|| {
-            let mut rx_set = IpcReceiverSet::new().unwrap();
-            {
-                {
-                    let (_, rx) = ipc::channel::<()>().unwrap();
-                    rx_set.add(rx).unwrap();
+            for _ in 0..to_send {
+                let (tx, rx) = ipc::channel().unwrap();
+                rx_set.add(rx).unwrap();
+                active.push(tx);
+            }
+            for _ in to_send..n {
+                let (tx, rx) = ipc::channel::<()>().unwrap();
+                rx_set.add(rx).unwrap();
+                dormant.push(tx);
+            }
+            b.iter(|| {
+                for tx in active.iter() {
+                    tx.send(()).unwrap();
                 }
-                // On select Receivers with a "ClosedChannel" event
-                // will be closed
-                rx_set.select().unwrap();
+                let mut received = 0;
+                while received < to_send {
+                    for result in rx_set.select().unwrap().into_iter() {
+                        let (_, _) = result.unwrap();
+                        received += 1;
+                    }
+                }
+            });
+        }
+
+        fn create_empty_set() -> Result<IpcReceiverSet, ()> {
+            Ok(IpcReceiverSet::new().unwrap())
+        }
+
+        fn add_n_rxs(rx_set: &mut IpcReceiverSet, n: usize) -> () {
+            for _ in 0..n {
                 let (_, rx) = ipc::channel::<()>().unwrap();
                 rx_set.add(rx).unwrap();
             }
-        });
+        }
+
+        #[bench]
+        fn send_on_1_of_1(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 1, 1);
+        }
+
+        #[bench]
+        fn send_on_1_of_5(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 1, 5);
+        }
+
+        #[bench]
+        fn send_on_2_of_5(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 2, 5);
+        }
+
+        #[bench]
+        fn send_on_5_of_5(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 5, 5);
+        }
+
+        #[bench]
+        fn send_on_1_of_20(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 1, 20);
+        }
+
+        #[bench]
+        fn send_on_5_of_20(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 5, 20);
+        }
+
+        #[bench]
+        fn send_on_20_of_20(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 20, 20);
+        }
+
+        #[bench]
+        fn send_on_1_of_100(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 1, 100);
+        }
+
+        #[bench]
+        fn send_on_5_of_100(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 5, 100);
+        }
+        #[bench]
+        fn send_on_20_of_100(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 20, 100);
+        }
+
+        #[bench]
+        fn send_on_100_of_100(b: &mut test::Bencher) -> () {
+            gen_select_test(b, 100, 100);
+        }
+
+        #[bench]
+        fn create_and_destroy_empty_set(b: &mut test::Bencher) -> () {
+            b.iter(|| {
+                create_empty_set().unwrap();
+            });
+        }
+
+        #[bench]
+        fn create_and_destroy_set_of_10(b: &mut test::Bencher) -> () {
+            b.iter(|| {
+                let mut rx_set = IpcReceiverSet::new().unwrap();
+                add_n_rxs(&mut rx_set, 10);
+            });
+        }
+
+        #[bench]
+        fn create_and_destroy_set_of_5(b: &mut test::Bencher) -> () {
+            b.iter(|| {
+                let mut rx_set = IpcReceiverSet::new().unwrap();
+                add_n_rxs(&mut rx_set, 5);
+            });
+        }
+
+        #[bench]
+        // Benchmark adding and removing closed receivers from the set
+        fn add_and_remove_closed_receivers(b: &mut test::Bencher) -> () {
+            b.iter(|| {
+                let mut rx_set = IpcReceiverSet::new().unwrap();
+                {
+                    {
+                        let (_, rx) = ipc::channel::<()>().unwrap();
+                        rx_set.add(rx).unwrap();
+                    }
+                    // On select Receivers with a "ClosedChannel" event
+                    // will be closed
+                    rx_set.select().unwrap();
+                    let (_, rx) = ipc::channel::<()>().unwrap();
+                    rx_set.add(rx).unwrap();
+                }
+            });
+        }
     }
 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -185,7 +185,7 @@ mod ipc {
 
         // Benchmark selecting over a set of `n` receivers,
         // with `to_send` of them actually having pending data.
-        fn bench_send_on_m_of_n(b: &mut test::Bencher, to_send: usize, n: usize) -> () {
+        fn bench_send_on_m_of_n(b: &mut test::Bencher, to_send: usize, n: usize) {
             let mut active = Vec::with_capacity(to_send);
             let mut dormant = Vec::with_capacity(n - to_send);
             let mut rx_set = IpcReceiverSet::new().unwrap();
@@ -214,56 +214,56 @@ mod ipc {
         }
 
         #[bench]
-        fn send_on_1_of_1(b: &mut test::Bencher) -> () {
+        fn send_on_1_of_1(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 1, 1);
         }
 
         #[bench]
-        fn send_on_1_of_5(b: &mut test::Bencher) -> () {
+        fn send_on_1_of_5(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 1, 5);
         }
 
         #[bench]
-        fn send_on_2_of_5(b: &mut test::Bencher) -> () {
+        fn send_on_2_of_5(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 2, 5);
         }
 
         #[bench]
-        fn send_on_5_of_5(b: &mut test::Bencher) -> () {
+        fn send_on_5_of_5(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 5, 5);
         }
 
         #[bench]
-        fn send_on_1_of_20(b: &mut test::Bencher) -> () {
+        fn send_on_1_of_20(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 1, 20);
         }
 
         #[bench]
-        fn send_on_5_of_20(b: &mut test::Bencher) -> () {
+        fn send_on_5_of_20(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 5, 20);
         }
 
         #[bench]
-        fn send_on_20_of_20(b: &mut test::Bencher) -> () {
+        fn send_on_20_of_20(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 20, 20);
         }
 
         #[bench]
-        fn send_on_1_of_100(b: &mut test::Bencher) -> () {
+        fn send_on_1_of_100(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 1, 100);
         }
 
         #[bench]
-        fn send_on_5_of_100(b: &mut test::Bencher) -> () {
+        fn send_on_5_of_100(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 5, 100);
         }
         #[bench]
-        fn send_on_20_of_100(b: &mut test::Bencher) -> () {
+        fn send_on_20_of_100(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 20, 100);
         }
 
         #[bench]
-        fn send_on_100_of_100(b: &mut test::Bencher) -> () {
+        fn send_on_100_of_100(b: &mut test::Bencher) {
             bench_send_on_m_of_n(b, 100, 100);
         }
 
@@ -277,28 +277,28 @@ mod ipc {
         }
 
         #[bench]
-        fn create_and_destroy_empty_set(b: &mut test::Bencher) -> () {
+        fn create_and_destroy_empty_set(b: &mut test::Bencher) {
             b.iter(|| {
                 create_set_of_n(0);
             });
         }
 
         #[bench]
-        fn create_and_destroy_set_of_1(b: &mut test::Bencher) -> () {
+        fn create_and_destroy_set_of_1(b: &mut test::Bencher) {
             b.iter(|| {
                 create_set_of_n(1);
             });
         }
 
         #[bench]
-        fn create_and_destroy_set_of_10(b: &mut test::Bencher) -> () {
+        fn create_and_destroy_set_of_10(b: &mut test::Bencher) {
             b.iter(|| {
                 create_set_of_n(10);
             });
         }
 
         #[bench]
-        fn create_and_destroy_set_of_100(b: &mut test::Bencher) -> () {
+        fn create_and_destroy_set_of_100(b: &mut test::Bencher) {
             b.iter(|| {
                 create_set_of_n(100);
             });

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -89,14 +89,16 @@ struct PollEntry {
 
 #[derive(PartialEq, Debug)]
 pub struct OsIpcReceiver {
-    fd: c_int,
+    fd: Cell<c_int>,
 }
 
 impl Drop for OsIpcReceiver {
     fn drop(&mut self) {
         unsafe {
-            let result = libc::close(self.fd);
-            assert!(thread::panicking() || result == 0);
+            if self.fd.get() >= 0 {
+                let result = libc::close(self.fd.get());
+                assert!(thread::panicking() || result == 0);
+            }
         }
     }
 }
@@ -104,14 +106,14 @@ impl Drop for OsIpcReceiver {
 impl OsIpcReceiver {
     fn from_fd(fd: c_int) -> OsIpcReceiver {
         OsIpcReceiver {
-            fd: fd,
+            fd: Cell::new(fd),
         }
     }
 
     fn consume_fd(&self) -> c_int {
-        unsafe {
-            libc::dup(self.fd)
-        }
+        let fd = self.fd.get();
+        self.fd.set(-1);
+        fd
     }
 
     pub fn consume(&self) -> OsIpcReceiver {
@@ -120,12 +122,12 @@ impl OsIpcReceiver {
 
     pub fn recv(&self)
                 -> Result<(Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>),UnixError> {
-        recv(self.fd, BlockingMode::Blocking)
+        recv(self.fd.get(), BlockingMode::Blocking)
     }
 
     pub fn try_recv(&self)
                     -> Result<(Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>),UnixError> {
-        recv(self.fd, BlockingMode::Nonblocking)
+        recv(self.fd.get(), BlockingMode::Nonblocking)
     }
 }
 
@@ -353,7 +355,7 @@ impl OsIpcSender {
         // along any other file descriptors that are to be transferred in the message.
         let (dedicated_tx, dedicated_rx) = try!(channel());
         // Extract FD handle without consuming the Receiver, so the FD doesn't get closed.
-        fds.push(dedicated_rx.fd);
+        fds.push(dedicated_rx.fd.get());
 
         // Split up the packet into fragments.
         let mut byte_position = 0;
@@ -415,7 +417,7 @@ impl OsIpcChannel {
     fn fd(&self) -> c_int {
         match *self {
             OsIpcChannel::Sender(ref sender) => sender.fd.0,
-            OsIpcChannel::Receiver(ref receiver) => receiver.fd,
+            OsIpcChannel::Receiver(ref receiver) => receiver.fd.get(),
         }
     }
 }
@@ -855,7 +857,7 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
             // Note: we always use blocking mode for followup fragments,
             // to make sure that once we start receiving a multi-fragment message,
             // we don't abort in the middle of it...
-            let result = libc::recv(dedicated_rx.fd,
+            let result = libc::recv(dedicated_rx.fd.get(),
                                     main_data_buffer[write_pos..].as_mut_ptr() as *mut c_void,
                                     end_pos - write_pos,
                                     0);

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -132,6 +132,14 @@ impl OsIpcReceiver {
 #[derive(PartialEq, Debug)]
 pub struct SharedFileDescriptor(c_int);
 
+impl Drop for SharedFileDescriptor {
+    fn drop(&mut self) {
+        unsafe {
+            let result = libc::close(self.0);
+            assert!(thread::panicking() || result == 0);
+        }
+    }
+}
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct OsIpcSender {
@@ -141,15 +149,6 @@ pub struct OsIpcSender {
     // (Rather, senders should just be cloned, as they are shared internally anyway --
     // another layer of sharing only adds unnecessary overhead...)
     nosync_marker: PhantomData<Cell<()>>,
-}
-
-impl Drop for SharedFileDescriptor {
-    fn drop(&mut self) {
-        unsafe {
-            let result = libc::close(self.0);
-            assert!(thread::panicking() || result == 0);
-        }
-    }
 }
 
 impl OsIpcSender {

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -95,8 +95,8 @@ pub struct OsIpcReceiver {
 impl Drop for OsIpcReceiver {
     fn drop(&mut self) {
         unsafe {
-            //assert!(libc::close(self.fd) == 0)
-            libc::close(self.fd);
+            let result = libc::close(self.fd);
+            assert!(thread::panicking() || result == 0);
         }
     }
 }
@@ -534,7 +534,8 @@ pub struct OsOpaqueIpcChannel {
 impl Drop for OsOpaqueIpcChannel {
     fn drop(&mut self) {
         unsafe {
-            libc::close(self.fd); 
+            let result = libc::close(self.fd);
+            assert!(thread::panicking() || result == 0);
         }
     }
 }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -129,7 +129,7 @@ impl OsIpcReceiver {
     }
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug)]
 pub struct SharedFileDescriptor(c_int);
 
 

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -620,9 +620,7 @@ impl OsIpcOneShotServer {
             }
             try!(make_socket_lingering(client_fd));
 
-            let receiver = OsIpcReceiver {
-                fd: client_fd,
-            };
+            let receiver = OsIpcReceiver::from_fd(client_fd);
             let (data, channels, shared_memory_regions) = try!(receiver.recv());
             Ok((receiver, data, channels, shared_memory_regions))
         }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -130,7 +130,7 @@ impl OsIpcReceiver {
 }
 
 #[derive(PartialEq, Debug)]
-pub struct SharedFileDescriptor(c_int);
+struct SharedFileDescriptor(c_int);
 
 impl Drop for SharedFileDescriptor {
     fn drop(&mut self) {


### PR DESCRIPTION
This makes a bunch of changes to how FDs are handled in the Unix back-end: most notably, adding inner mutability for the FD in `OsIpcReceiver` by wrapping it in a `Cell<>`, just like the other back-ends do -- thus enabling us to avoid unnecessary `dup()` calls when passing around FDs, without introducing potential FD leaks or premature closing.

This also contains a couple of related cleanups and minor fixes. Furthermore, it adds benchmarks for FD passing, to track the effect of the optimisations; and a bunch of improvements to the existing benchmarks for receiver set handling.