### PR TITLE
platform/unix: Use `reserve_exact()` in `recv()`

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -838,7 +838,7 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
 
     // Extend the buffer to hold the entire message, without initialising the memory.
     let len = main_data_buffer.len();
-    main_data_buffer.reserve(total_size - len);
+    main_data_buffer.reserve_exact(total_size - len);
 
     // Receive followup fragments directly into the main buffer.
     while main_data_buffer.len() < total_size {


### PR DESCRIPTION
Since we know exactly at this point how large the message will be, there
is no point in allowing the allocator to reserve more.

While this doesn't actually show any measurable difference here, it
still seems useful to express the constraint explicitly in the code --
to account for possible differences in allocators, for example; and
possibly for clarity?