### PR TITLE
Avoid using `include!()` for platform modules

### DIFF
--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -21,7 +21,7 @@ use std::mem;
 use std::usize;
 use uuid::Uuid;
 
-use super::Incrementor;
+use super::incrementor::Incrementor;
 
 #[derive(Clone)]
 struct ServerRecord {

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -19,8 +19,9 @@ use std::cmp::{PartialEq};
 use std::ops::Deref;
 use std::mem;
 use std::usize;
-
 use uuid::Uuid;
+
+use super::Incrementor;
 
 #[derive(Clone)]
 struct ServerRecord {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -38,13 +38,23 @@ mod inprocess;
 
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "freebsd")))]
-pub use self::unix::*;
+mod os {
+    pub use super::unix::*;
+}
 
 #[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
-pub use self::macos::*;
+mod os {
+    pub use super::macos::*;
+}
 
 #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
-pub use self::inprocess::*;
+mod os {
+    pub use super::inprocess::*;
+}
+
+pub use self::os::{OsIpcChannel, OsIpcOneShotServer, OsIpcReceiver, OsIpcReceiverSet};
+pub use self::os::{OsIpcSelectionResult, OsIpcSender, OsIpcSharedMemory};
+pub use self::os::{OsOpaqueIpcChannel, channel};
 
 #[cfg(test)]
 mod test;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,21 +8,22 @@
 // except according to those terms.
 
 #[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
-struct Incrementor {
-    last_value: u64,
-}
-
-#[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
-impl Incrementor {
-    fn new() -> Incrementor {
-        Incrementor {
-            last_value: 0
-        }
+mod incrementor {
+    pub struct Incrementor {
+        last_value: u64,
     }
 
-    fn increment(&mut self) -> u64 {
-        self.last_value += 1;
-        self.last_value
+    impl Incrementor {
+        pub fn new() -> Incrementor {
+            Incrementor {
+                last_value: 0
+            }
+        }
+
+        pub fn increment(&mut self) -> u64 {
+            self.last_value += 1;
+            self.last_value
+        }
     }
 }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -29,13 +29,6 @@ impl Incrementor {
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "freebsd")))]
 mod unix;
-
-#[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
-mod macos;
-
-#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
-mod inprocess;
-
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "freebsd")))]
 mod os {
@@ -43,10 +36,14 @@ mod os {
 }
 
 #[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
+mod macos;
+#[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
 mod os {
     pub use super::macos::*;
 }
 
+#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
+mod inprocess;
 #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
 mod os {
     pub use super::inprocess::*;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,40 +7,44 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-mod os {
-    #[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
-    struct Incrementor {
-        last_value: u64,
-    }
-
-    #[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
-    impl Incrementor {
-        fn new() -> Incrementor {
-            Incrementor {
-                last_value: 0
-            }
-        }
-
-        fn increment(&mut self) -> u64 {
-            self.last_value += 1;
-            self.last_value
-        }
-    }
-
-    #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                    target_os = "freebsd")))]
-    include!("unix/mod.rs");
-
-    #[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
-    include!("macos/mod.rs");
-
-    #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
-    include!("inprocess/mod.rs");
+#[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
+struct Incrementor {
+    last_value: u64,
 }
 
-pub use self::os::{OsIpcChannel, OsIpcOneShotServer, OsIpcReceiver, OsIpcReceiverSet};
-pub use self::os::{OsIpcSelectionResult, OsIpcSender, OsIpcSharedMemory};
-pub use self::os::{OsOpaqueIpcChannel, channel};
+#[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
+impl Incrementor {
+    fn new() -> Incrementor {
+        Incrementor {
+            last_value: 0
+        }
+    }
+
+    fn increment(&mut self) -> u64 {
+        self.last_value += 1;
+        self.last_value
+    }
+}
+
+#[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "freebsd")))]
+mod unix;
+
+#[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
+mod macos;
+
+#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
+mod inprocess;
+
+#[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "freebsd")))]
+pub use self::unix::*;
+
+#[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
+pub use self::macos::*;
+
+#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
+pub use self::inprocess::*;
 
 #[cfg(test)]
 mod test;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
 mod incrementor {
     pub struct Incrementor {
         last_value: u64,

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -30,7 +30,7 @@ use std::thread;
 use mio::unix::EventedFd;
 use mio::{Poll, Token, Events, Ready, PollOpt};
 
-use super::Incrementor;
+use super::incrementor::Incrementor;
 
 const MAX_FDS_IN_CMSG: u32 = 64;
 

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -30,6 +30,8 @@ use std::thread;
 use mio::unix::EventedFd;
 use mio::{Poll, Token, Events, Ready, PollOpt};
 
+use super::Incrementor;
+
 const MAX_FDS_IN_CMSG: u32 = 64;
 
 const SCM_RIGHTS: c_int = 0x01;


### PR DESCRIPTION
Using `include!()` apparently breaks debug info, according to 
https://github.com/servo/ipc-channel/pull/108#discussion_r85535672 -- so
avoid it by going back to per-backend modules.

(Extracted from https://github.com/servo/ipc-channel/pull/108 , since
it's unrelated to the actual purpose of that PR.)

This PR also contains a couple of more or less related cleanups.