### PR TITLE
tests: `fork()`: Automatically exit child process after closure returns

### DIFF
--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -14,8 +14,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::thread;
 
-#[cfg(not(any(feature = "force-inprocess", target_os = "windows", target_os = "android")))]
-use libc;
 use platform::{OsIpcSender, OsIpcOneShotServer};
 #[cfg(not(any(feature = "force-inprocess", target_os = "windows", target_os = "android")))]
 use test::{fork, Wait};
@@ -634,7 +632,6 @@ fn cross_process() {
     let child_pid = unsafe { fork(|| {
         let tx = OsIpcSender::connect(name).unwrap();
         tx.send(data, vec![], vec![]).unwrap();
-        libc::exit(0);
     })};
 
     let (_, mut received_data, received_channels, received_shared_memory_regions) =
@@ -658,7 +655,6 @@ fn cross_process_sender_transfer() {
         sub_rx.recv().unwrap();
         let data: &[u8] = b"bar";
         super_tx.send(data, vec![], vec![]).unwrap();
-        libc::exit(0);
     })};
 
     let (super_rx, _, mut received_channels, _) = server.accept().unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -30,7 +30,10 @@ use std::io::Error;
 pub unsafe fn fork<F: FnOnce()>(child_func: F) -> libc::pid_t {
     match libc::fork() {
         -1 => panic!("Fork failed: {}", Error::last_os_error()),
-        0 => { child_func(); unreachable!() },
+        0 => {
+            child_func();
+            libc::exit(0);
+        },
         pid => pid,
     }
 }
@@ -148,7 +151,6 @@ fn cross_process_embedded_senders() {
         rx1.recv().unwrap();
         let tx2: IpcSender<Person> = IpcSender::connect(server2_name).unwrap();
         tx2.send(person.clone()).unwrap();
-        libc::exit(0);
     })};
     let (_, tx1): (_, IpcSender<Person>) = server0.accept().unwrap();
     tx1.send(person.clone()).unwrap();


### PR DESCRIPTION
Rather than panicking, just exit the process cleanly.

The idea with this was that the closure is never supposed to return,
since chaos would ensue otherwise, as the child process and the parent
process would continue running the rest of the test suite.

However, the existing `unreachable!()` panic that was supposed to
enforce this, effectively just terminated the process anyway. The panic
message wouldn't even show up unless using `--nocapture`. So we can just
as well make this official, so callers are no longer required to exit
the process explicitly. This actually makes use of `fork()` more
ergonomic.