### PR TITLE
Use memfd_create and shm_open instead of mkstemp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: rust
 sudo: false
-rust:
-  - nightly
 
-os:
-  - linux
-  - osx
-
-env:
-  - FEATURES="unstable"
-  - FEATURES="unstable force-inprocess"
+matrix:
+  include:
+    - os: linux
+      rust: nightly
+      env: FEATURES="unstable"
+    - os: linux
+      rust: nightly
+      env: FEATURES="unstable force-inprocess"
+    - os: linux
+      rust: nightly
+      env: FEATURES="unstable memfd"
+    - os: osx
+      rust: nightly
+      env: FEATURES="unstable"
+    - os: osx
+      rust: nightly
+      env: FEATURES="unstable force-inprocess"
 
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/servo/ipc-channel"
 
 [features]
 force-inprocess = []
+memfd = ["syscall"]
 unstable = []
 
 [dependencies]
@@ -21,6 +22,8 @@ fnv = "1.0.3"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 mio = "0.6.1"
+
+syscall = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 crossbeam = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,11 @@ extern crate mio;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "freebsd")))]
 extern crate fnv;
+#[cfg(all(feature = "memfd", not(feature = "force-inprocess"),
+          target_os="linux"))]
+#[macro_use]
+extern crate syscall;
+
 
 pub mod ipc;
 pub mod platform;


### PR DESCRIPTION
Remove the use of `mkstemp` which creates a file in `/tmp`. Instead use the following

 - `linux` - [`memfd_create`](http://man7.org/linux/man-pages/man2/memfd_create.2.html)
 - `freebsd` - [`shm_open`](https://www.freebsd.org/cgi/man.cgi?query=shm_open&sektion=2)