### PR TITLE
Reexport bincode errors from the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.6.1"
+version = "0.6.2"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -10,8 +10,8 @@
 use platform::{self, OsIpcChannel, OsIpcReceiver, OsIpcReceiverSet, OsIpcSender};
 use platform::{OsIpcOneShotServer, OsIpcSelectionResult, OsIpcSharedMemory, OsOpaqueIpcChannel};
 
+use {DeserializeError, SerializeError};
 use bincode::{self, SizeLimit};
-use bincode::serde::{DeserializeError, SerializeError};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cell::RefCell;
 use std::cmp::min;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,4 @@ pub mod router;
 #[cfg(test)]
 mod test;
 
+pub use bincode::serde::{DeserializeError, SerializeError};

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use bincode::serde::{DeserializeError, SerializeError};
+use {DeserializeError, SerializeError};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::collections::hash_map::HashMap;

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -12,7 +12,7 @@ use self::mach_sys::{mach_msg_ool_descriptor_t, mach_msg_port_descriptor_t};
 use self::mach_sys::{mach_msg_timeout_t, mach_port_limits_t, mach_port_msgcount_t};
 use self::mach_sys::{mach_port_right_t, mach_port_t, mach_task_self_, vm_inherit_t};
 
-use bincode::serde::{DeserializeError, SerializeError};
+use {DeserializeError, SerializeError};
 use libc::{self, c_char, c_uint, c_void, size_t};
 use rand::{self, Rng};
 use std::cell::Cell;

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use {DeserializeError, SerializeError};
 use fnv::FnvHasher;
-use bincode::serde::{DeserializeError, SerializeError};
 use libc::{self, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE, SOCK_SEQPACKET, SOL_SOCKET};
 use libc::{SO_LINGER, S_IFMT, S_IFSOCK, c_char, c_int, c_void, getsockopt};
 use libc::{iovec, mkstemp, mode_t, msghdr, off_t, recvmsg, sendmsg};


### PR DESCRIPTION
This allows users to not have to depend on bincode from everywhere they use ipc-channel.