### PR TITLE
Use slab for unix OsIpcReceiverSet's tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ libc = "0.2.12"
 rand = "0.3"
 serde = "0.8"
 uuid = {version = "0.3", features = ["v4"]}
-fnv = "1.0.3"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 mio = "0.6.1"
+slab = "0.3.0"
 
 [dev-dependencies]
 crossbeam = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ extern crate uuid;
 extern crate mio;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "freebsd")))]
-extern crate fnv;
+extern crate slab;
 
 pub mod ipc;
 pub mod platform;


### PR DESCRIPTION
Use slab as the container for OsIpcReceiverSet's tokens and fds.

Resolves:
 - servo/ipc-channel#133

Related to:
 - servo/servo#15537