### PR TITLE
platform/unix: Don't return ECONNRESET if dedicated channel is closed

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -881,7 +881,13 @@ fn recv(fd: c_int, blocking_mode: BlockingMode)
         };
 
         if result == 0 {
-            return Err(UnixError(libc::ECONNRESET))
+            // If we stop receiving data before we got the expected amount,
+            // something must have gone seriously wrong.
+            //
+            // EIO doesn't seem like a really good choice --
+            // but probably about the best we can do
+            // without completely overhauling the Error types used here...
+            return Err(UnixError(libc::EIO))
         } else if result < 0 {
             return Err(UnixError::last())
         };


### PR DESCRIPTION
So far, when the sender of a dedicated channel in a large transfer was
closed before the receiver got the expected amount of data, `recv()`
returned a "channel closed" status, just as if the main channel was
closed. This is incorrect though, since the main channel is still open,
and the receiver shouldn't be dropped.

Returning `EIO` now instead -- which is a bit of an abuse I guess; but
probably as good a choice as any, as long as we are sticking with Unix
error codes only...