### PR TITLE
Added sender.send_borrowed(data), to reduce copying

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "0.2"
 libc = "0.2.12"
 rand = "0.3"
 serde = "0.9"
+serde_roundtrip = "0.1"
 uuid = {version = "0.4", features = ["v4"]}
 fnv = "1.0.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ extern crate bincode;
 extern crate libc;
 extern crate rand;
 extern crate serde;
+extern crate serde_roundtrip;
 #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android"))]
 extern crate uuid;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",

--- a/src/test.rs
+++ b/src/test.rs
@@ -322,6 +322,16 @@ fn embedded_opaque_senders() {
 }
 
 #[test]
+fn send_borrowed() {
+    let person = ("Patrick Walton", 29);
+    let (tx, rx) = ipc::channel().unwrap();
+    tx.send_borrowed(&person).unwrap();
+    let received_person: Person = rx.recv().unwrap();
+    assert_eq!(person.0, received_person.0);
+    assert_eq!(person.1, received_person.1);
+}
+
+#[test]
 fn try_recv() {
     let person = ("Patrick Walton".to_owned(), 29);
     let (tx, rx) = ipc::channel().unwrap();


### PR DESCRIPTION
For compatibility with channels, senders take ownership of their data, and drop it immediately after sending. This PR adds the ability to send borrowed data, including nested data, for example sending a `&(&str,u32)` on a sender expecting a `(String,u32)`.

cc @nox @antrik.

Fixes #156.