### PR TITLE
Remove need to truncate mach IPC results

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -435,12 +435,6 @@ impl OsIpcSender {
             data_dest = data_dest.offset(mem::size_of::<usize>() as isize);
             ptr::copy_nonoverlapping(data.as_ptr(), data_dest, data_size);
 
-            let mut ptr = message as *const u32;
-            let end = (message as *const u8).offset(size as isize) as *const u32;
-            while ptr < end {
-                ptr = ptr.offset(1);
-            }
-
             let os_result = mach_sys::mach_msg(message as *mut _,
                                                MACH_SEND_MSG,
                                                (*message).header.msgh_size,

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -25,8 +25,7 @@ fn simple() {
     let (tx, rx) = platform::channel().unwrap();
     let data: &[u8] = b"1234567";
     tx.send(data, Vec::new(), Vec::new()).unwrap();
-    let (mut received_data, received_channels, received_shared_memory) = rx.recv().unwrap();
-    received_data.truncate(7);
+    let (received_data, received_channels, received_shared_memory) = rx.recv().unwrap();
     assert_eq!((&received_data[..], received_channels, received_shared_memory),
                (data, Vec::new(), Vec::new()));
 }
@@ -41,9 +40,8 @@ fn sender_transfer() {
     assert_eq!(received_channels.len(), 1);
     let sub_tx = received_channels.pop().unwrap().to_sender();
     sub_tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(3);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -58,9 +56,8 @@ fn receiver_transfer() {
     assert_eq!(received_channels.len(), 1);
     let sub_rx = received_channels.pop().unwrap().to_receiver();
     sub_tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(3);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -79,17 +76,15 @@ fn multisender_transfer() {
 
     let sub0_tx = received_channels.remove(0).to_sender();
     sub0_tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_subchannels, received_shared_memory_regions) =
+    let (received_data, received_subchannels, received_shared_memory_regions) =
         sub0_rx.recv().unwrap();
-    received_data.truncate(8);
     assert_eq!((&received_data[..], received_subchannels, received_shared_memory_regions),
                (data, vec![], vec![]));
 
     let sub1_tx = received_channels.remove(0).to_sender();
     sub1_tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_subchannels, received_shared_memory_regions) =
+    let (received_data, received_subchannels, received_shared_memory_regions) =
         sub1_rx.recv().unwrap();
-    received_data.truncate(8);
     assert_eq!((&received_data[..], received_subchannels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -100,9 +95,8 @@ fn medium_data() {
     let data: &[u8] = &data[..];
     let (tx, rx) = platform::channel().unwrap();
     tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         rx.recv().unwrap();
-    received_data.truncate(65536);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
 }
@@ -118,9 +112,8 @@ fn medium_data_with_sender_transfer() {
     assert_eq!(received_channels.len(), 1);
     let sub_tx = received_channels.pop().unwrap().to_sender();
     sub_tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(65536);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -133,11 +126,10 @@ fn big_data() {
         let data: &[u8] = &data[..];
         tx.send(data, vec![], vec![]).unwrap();
     });
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         rx.recv().unwrap();
     let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
-    received_data.truncate(1024 * 1024);
     assert_eq!(received_data.len(), data.len());
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
@@ -153,11 +145,10 @@ fn big_data_with_sender_transfer() {
         let data: &[u8] = &data[..];
         super_tx.send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![]).unwrap();
     });
-    let (mut received_data, mut received_channels, received_shared_memory_regions) =
+    let (received_data, mut received_channels, received_shared_memory_regions) =
         super_rx.recv().unwrap();
     let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
-    received_data.truncate(1024 * 1024);
     assert_eq!(received_data.len(), data.len());
     assert_eq!(&received_data[..], &data[..]);
     assert_eq!(received_channels.len(), 1);
@@ -167,9 +158,8 @@ fn big_data_with_sender_transfer() {
     let data: &[u8] = &data[..];
     let sub_tx = received_channels[0].to_sender();
     sub_tx.send(data, vec![], vec![]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         sub_rx.recv().unwrap();
-    received_data.truncate(65536);
     assert_eq!(received_data.len(), data.len());
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
@@ -184,10 +174,9 @@ fn with_n_fds(n: usize, size: usize) {
 
     let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
     super_tx.send(&data[..], sender_fds, vec![]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         super_rx.recv().unwrap();
 
-    received_data.truncate(size);
     assert_eq!(received_data.len(), data.len());
     assert_eq!(&received_data[..], &data[..]);
     assert_eq!(received_channels.len(), receivers.len());
@@ -197,9 +186,8 @@ fn with_n_fds(n: usize, size: usize) {
     for (mut sender_fd, sub_rx) in received_channels.into_iter().zip(receivers.into_iter()) {
         let sub_tx = sender_fd.to_sender();
         sub_tx.send(&data[..], vec![], vec![]).unwrap();
-        let (mut received_data, received_channels, received_shared_memory_regions) =
+        let (received_data, received_channels, received_shared_memory_regions) =
             sub_rx.recv().unwrap();
-        received_data.truncate(65536);
         assert_eq!(received_data.len(), data.len());
         assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                    (&data[..], vec![], vec![]));
@@ -297,13 +285,12 @@ macro_rules! create_big_data_with_n_fds {
                 let data: &[u8] = &data[..];
                 super_tx.send(data, sender_fds, vec![]).unwrap();
             });
-            let (mut received_data, received_channels, received_shared_memory_regions) =
+            let (received_data, received_channels, received_shared_memory_regions) =
                 super_rx.recv().unwrap();
             thread.join().unwrap();
 
             let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
             let data: &[u8] = &data[..];
-            received_data.truncate(1024 * 1024);
             assert_eq!(received_data.len(), data.len());
             assert_eq!(&received_data[..], &data[..]);
             assert_eq!(received_channels.len(), receivers.len());
@@ -314,9 +301,8 @@ macro_rules! create_big_data_with_n_fds {
             for (mut sender_fd, sub_rx) in received_channels.into_iter().zip(receivers.into_iter()) {
                 let sub_tx = sender_fd.to_sender();
                 sub_tx.send(data, vec![], vec![]).unwrap();
-                let (mut received_data, received_channels, received_shared_memory_regions) =
+                let (received_data, received_channels, received_shared_memory_regions) =
                     sub_rx.recv().unwrap();
-                received_data.truncate(65536);
                 assert_eq!(received_data.len(), data.len());
                 assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                            (&data[..], vec![], vec![]));
@@ -350,13 +336,12 @@ fn concurrent_senders() {
 
     let mut received_vals: Vec<u8> = vec![];
     for _ in 0..num_senders {
-        let (mut received_data, received_channels, received_shared_memory_regions) =
+        let (received_data, received_channels, received_shared_memory_regions) =
             rx.recv().unwrap();
         let val = received_data[0] >> 4;
         received_vals.push(val);
         let data: Vec<u8> = (0.. 1024 * 1024).map(|j| (j % 13) as u8 | val << 4).collect();
         let data: &[u8] = &data[..];
-        received_data.truncate(1024 * 1024);
         assert_eq!(received_data.len(), data.len());
         assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                    (&data[..], vec![], vec![]));
@@ -380,16 +365,14 @@ fn receiver_set() {
 
     let data: &[u8] = b"1234567";
     tx0.send(data, vec![], vec![]).unwrap();
-    let (received_id, mut received_data, _, _) =
+    let (received_id, received_data, _, _) =
         rx_set.select().unwrap().into_iter().next().unwrap().unwrap();
-    received_data.truncate(7);
     assert_eq!(received_id, rx0_id);
     assert_eq!(received_data, data);
 
     tx1.send(data, vec![], vec![]).unwrap();
-    let (received_id, mut received_data, _, _) =
+    let (received_id, received_data, _, _) =
         rx_set.select().unwrap().into_iter().next().unwrap().unwrap();
-    received_data.truncate(7);
     assert_eq!(received_id, rx1_id);
     assert_eq!(received_data, data);
 
@@ -398,8 +381,7 @@ fn receiver_set() {
     let (mut received0, mut received1) = (false, false);
     while !received0 || !received1 {
         for result in rx_set.select().unwrap().into_iter() {
-            let (received_id, mut received_data, _, _) = result.unwrap();
-            received_data.truncate(7);
+            let (received_id, received_data, _, _) = result.unwrap();
             assert_eq!(received_data, data);
             assert!(received_id == rx0_id || received_id == rx1_id);
             if received_id == rx0_id {
@@ -638,9 +620,8 @@ fn server_accept_first() {
         tx.send(data, vec![], vec![]).unwrap();
     });
 
-    let (_, mut received_data, received_channels, received_shared_memory_regions) =
+    let (_, received_data, received_channels, received_shared_memory_regions) =
         server.accept().unwrap();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -674,10 +655,9 @@ fn cross_process() {
         tx.send(data, vec![], vec![]).unwrap();
     })};
 
-    let (_, mut received_data, received_channels, received_shared_memory_regions) =
+    let (_, received_data, received_channels, received_shared_memory_regions) =
         server.accept().unwrap();
     child_pid.wait();
-    received_data.truncate(7);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -704,10 +684,9 @@ fn cross_process_sender_transfer() {
     sub_tx.send(data, vec![], vec![]).unwrap();
 
     let data: &[u8] = b"bar";
-    let (mut received_data, received_channels, received_shared_memory_regions) =
+    let (received_data, received_channels, received_shared_memory_regions) =
         super_rx.recv().unwrap();
     child_pid.wait();
-    received_data.truncate(3);
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (data, vec![], vec![]));
 }
@@ -727,8 +706,7 @@ fn shared_memory() {
     let data: &[u8] = b"1234567";
     let shmem_data = OsIpcSharedMemory::from_byte(0xba, 1024 * 1024);
     tx.send(data, vec![], vec![shmem_data]).unwrap();
-    let (mut received_data, received_channels, received_shared_memory) = rx.recv().unwrap();
-    received_data.truncate(7);
+    let (received_data, received_channels, received_shared_memory) = rx.recv().unwrap();
     assert_eq!((&received_data[..], received_channels), (data, Vec::new()));
     assert_eq!(received_shared_memory[0].len(), 1024 * 1024);
     assert!(received_shared_memory[0].iter().all(|byte| *byte == 0xba));
@@ -747,8 +725,7 @@ fn try_recv() {
     assert!(rx.try_recv().is_err());
     let data: &[u8] = b"1234567";
     tx.send(data, Vec::new(), Vec::new()).unwrap();
-    let (mut received_data, received_channels, received_shared_memory) = rx.try_recv().unwrap();
-    received_data.truncate(7);
+    let (received_data, received_channels, received_shared_memory) = rx.try_recv().unwrap();
     assert_eq!((&received_data[..], received_channels, received_shared_memory),
                (data, Vec::new(), Vec::new()));
     assert!(rx.try_recv().is_err());
@@ -771,11 +748,10 @@ fn try_recv_large() {
         result.is_err()
     } {}
     thread.join().unwrap();
-    let (mut received_data, received_channels, received_shared_memory) = result.unwrap();
+    let (received_data, received_channels, received_shared_memory) = result.unwrap();
 
     let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
-    received_data.truncate(1024 * 1024);
     assert_eq!((&received_data[..], received_channels, received_shared_memory),
                (data, vec![], vec![]));
     assert!(rx.try_recv().is_err());
@@ -837,8 +813,7 @@ fn try_recv_large_delayed() {
             result = rx.try_recv();
             result.is_err()
         } {}
-        let (mut received_data, received_channels, received_shared_memory) = result.unwrap();
-        received_data.truncate(msg_size);
+        let (received_data, received_channels, received_shared_memory) = result.unwrap();
 
         let val = received_data[0] >> 4;
         received_vals.push(val);

--- a/src/test.rs
+++ b/src/test.rs
@@ -358,7 +358,8 @@ fn multiple_paths_to_a_sender() {
 
 #[test]
 fn bytes() {
-    let bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+    // N.B. We're using an odd number of bytes here to expose alignment issues.
+    let bytes = [1, 2, 3, 4, 5, 6, 7];
     let (tx, rx) = ipc::bytes_channel().unwrap();
     tx.send(&bytes[..]).unwrap();
     let received_bytes = rx.recv().unwrap();
@@ -371,7 +372,7 @@ fn embedded_bytes_receivers() {
     let (super_tx, super_rx) = ipc::channel().unwrap();
     super_tx.send(sub_tx).unwrap();
     let sub_tx = super_rx.recv().unwrap();
-    let bytes = [1, 2, 3, 4, 5, 6, 7, 8];
+    let bytes = [1, 2, 3, 4, 5, 6, 7];
     sub_tx.send(&bytes[..]).unwrap();
     let received_bytes = sub_rx.recv().unwrap();
     assert_eq!(&bytes, &received_bytes[..]);


### PR DESCRIPTION
Mach's IPC requires 4 byte alignment. The code that receives data does not account for that right now; these changes ensure that the returned buffer is the same size as the original buffer that was sent. Fixes #83. Fixes #103.