### PR TITLE
Add Stream and Sink future traits to IpcSender and Receiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.3"
 serde = "0.9"
 uuid = {version = "0.4", features = ["v4"]}
 fnv = "1.0.3"
+futures = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 mio = "0.6.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate fnv;
           target_os="linux"))]
 #[macro_use]
 extern crate syscall;
+extern crate futures;
 
 
 pub mod ipc;


### PR DESCRIPTION
It would be cool if this could work with async futures-rs. I think this will make servo/servo#16236 a lot easier.

So far `Stream` for `IpcReceiver` was pretty straightforward, but I'm wondering about `IpcSender`. Does anyone have any tips on how to move forward with the sender? I need to implemented `start_send` and `poll_complete` and I'm not sure how to logically break up the sending code into those two methods.
