### PR TITLE
Re-export bincode ErrorKind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,4 @@ pub mod router;
 #[cfg(test)]
 mod test;
 
-pub use bincode::Error;
+pub use bincode::{Error, ErrorKind};


### PR DESCRIPTION
This would allow for better introspection on the error occurred without hooking up to `bincode` explicitly.