### PR TITLE
tests: `server_accept_first()`: Drop bogus exclusion

### DIFF
--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -608,7 +608,6 @@ fn receiver_set_concurrent() {
     }
 }
 
-#[cfg(not(any(feature = "force-inprocess", target_os = "android")))]
 #[test]
 fn server_accept_first() {
     let (server, name) = OsIpcOneShotServer::new().unwrap();


### PR DESCRIPTION
I should have removed this conditional entirely (rather than just the
Windows part) in 7881984ac9dd446525e2aa8040cb205c111d6da9 . The issue
was never really Windows-specific in the first place: it just didn't
become apparent until we could test the `inprocess` back-end on other
platforms after 3e9aee8ead2c16ef15432300bfd189ba23f70989 .

(Also, this should have used the "ignore" attribute, rather than
conditional compilation: there was never any reason why the test
couldn't be run on Windows, or on the `inprocess` back-end in general --
it uncovered an actual bug in the `inprocess` back-end
implementation...)