### PR TITLE
Update to bincode 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.8.0"
+version = "0.9.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ unstable = []
 async = ["futures"]
 
 [dependencies]
-bincode = "0.8"
+bincode = "0.9"
 lazy_static = "0.2"
 libc = "0.2.12"
 rand = "0.3"


### PR DESCRIPTION
bincode 0.9 comes with a reasonably big performance fix for
deserialization. WebRender has already switched.