### PR TITLE
Mio updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ uuid = {version = "0.5", features = ["v4"]}
 fnv = "1.0.3"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
-mio = "0.6.1"
+mio = "0.6.11"
 
 syscall = { version = "0.2.1", optional = true }
 futures = { version = "0.1", optional = true }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -492,7 +492,7 @@ impl OsIpcReceiverSet {
 
         for evt in self.events.iter() {
             let evt_token = evt.token();
-            match (evt.kind().is_readable(), self.pollfds.get(&evt_token)) {
+            match (evt.readiness().is_readable(), self.pollfds.get(&evt_token)) {
                 (true, Some(&poll_entry)) => {
                     match recv(poll_entry.fd, BlockingMode::Blocking) {
                         Ok((data, channels, shared_memory_regions)) => {
@@ -514,8 +514,8 @@ impl OsIpcReceiverSet {
                     }
                 },
                 (true, None) => {
-                    panic!("Readable event for unknown token: {:?}, kind: {:?}",
-                           evt_token, evt.kind());
+                    panic!("Readable event for unknown token: {:?}, readiness: {:?}",
+                           evt_token, evt.readiness());
                 },
                 (false, _) => {
                     panic!("Received an event that was not readable for token: {:?}", evt_token)


### PR DESCRIPTION
`Event::kind` has been deprecated for `Event::readiness`. Replace all
usages of `Event::kind` for `Event::readiness`. Bump mio version.