### PR TITLE
cleanup: Use `RangeFrom` rather than custom `Incrementor`

### DIFF
--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -16,12 +16,10 @@ use std::io::{Error, ErrorKind};
 use std::slice;
 use std::fmt::{self, Debug, Formatter};
 use std::cmp::{PartialEq};
-use std::ops::Deref;
+use std::ops::{Deref, RangeFrom};
 use std::mem;
 use std::usize;
 use uuid::Uuid;
-
-use super::incrementor::Incrementor;
 
 #[derive(Clone)]
 struct ServerRecord {
@@ -149,7 +147,7 @@ impl OsIpcSender {
 }
 
 pub struct OsIpcReceiverSet {
-    incrementor: Incrementor,
+    incrementor: RangeFrom<u64>,
     receiver_ids: Vec<u64>,
     receivers: Vec<OsIpcReceiver>,
 }
@@ -157,14 +155,14 @@ pub struct OsIpcReceiverSet {
 impl OsIpcReceiverSet {
     pub fn new() -> Result<OsIpcReceiverSet,MpscError> {
         Ok(OsIpcReceiverSet {
-            incrementor: Incrementor::new(),
+            incrementor: 0..,
             receiver_ids: vec![],
             receivers: vec![],
         })
     }
 
     pub fn add(&mut self, receiver: OsIpcReceiver) -> Result<u64,MpscError> {
-        let last_index = self.incrementor.increment();
+        let last_index = self.incrementor.next().unwrap();
         self.receiver_ids.push(last_index);
         self.receivers.push(receiver.consume());
         Ok(last_index)

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -7,26 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[cfg(any(feature = "force-inprocess", not(target_os = "macos")))]
-mod incrementor {
-    pub struct Incrementor {
-        last_value: u64,
-    }
-
-    impl Incrementor {
-        pub fn new() -> Incrementor {
-            Incrementor {
-                last_value: 0
-            }
-        }
-
-        pub fn increment(&mut self) -> u64 {
-            self.last_value += 1;
-            self.last_value
-        }
-    }
-}
-
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
                                                 target_os = "freebsd")))]
 mod unix;


### PR DESCRIPTION
Use standard library functionality instead of custom class.

When I reviewed the PR that originally introduced this, it *did* feel
wrong to me to implement such a generic helper class in our code... But
for some reason it didn't occur to me that a simple range iterator is
the obvious answer.