### PR TITLE
OpenBSD & NetBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version="1.0", features=["rc"] }
 uuid = {version = "0.5", features = ["v4"]}
 fnv = "1.0.3"
 
-[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 mio = "0.6.11"
 
 syscall = { version = "0.2.1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,14 @@ extern crate serde;
 #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios"))]
 extern crate uuid;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                target_os = "freebsd")))]
+                                                target_os = "freebsd",
+                                                target_os = "netbsd",
+                                                target_os = "openbsd")))]
 extern crate mio;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                target_os = "freebsd")))]
+                                                target_os = "freebsd",
+                                                target_os = "netbsd",
+                                                target_os = "openbsd")))]
 extern crate fnv;
 #[cfg(all(feature = "memfd", not(feature = "force-inprocess"),
           target_os="linux"))]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,10 +8,14 @@
 // except according to those terms.
 
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                target_os = "freebsd")))]
+                                                target_os = "freebsd",
+                                                target_os = "netbsd",
+                                                target_os = "openbsd")))]
 mod unix;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                target_os = "freebsd")))]
+                                                target_os = "freebsd",
+                                                target_os = "netbsd",
+                                                target_os = "openbsd")))]
 mod os {
     pub use super::unix::*;
 }


### PR DESCRIPTION
Requires accounting for ancillary data in sending data. 63+ fd tests
are disabled, since this blocks on OpenBSD.

Also requires splitting sends and receives into separate threads during
testing.