### PR TITLE
Port to openbsd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version="1.0", features=["rc"] }
 uuid = {version = "0.6", features = ["v4"]}
 fnv = "1.0.3"
 
-[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
 mio = "0.6.11"
 
 sc = { version = "0.2.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,11 @@ extern crate serde;
 #[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios"))]
 extern crate uuid;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "openbsd",
                                                 target_os = "freebsd")))]
 extern crate mio;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "openbsd",
                                                 target_os = "freebsd")))]
 extern crate fnv;
 #[cfg(all(feature = "memfd", not(feature = "force-inprocess"),

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,9 +8,11 @@
 // except according to those terms.
 
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "openbsd",
                                                 target_os = "freebsd")))]
 mod unix;
 #[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "openbsd",
                                                 target_os = "freebsd")))]
 mod os {
     pub use super::unix::*;

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -46,9 +46,9 @@ type IovLen = usize;
 #[cfg(target_os = "linux")]
 type MsgControlLen = size_t;
 
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "openbsd", target_os = "freebsd"))]
 type IovLen = i32;
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "openbsd", target_os = "freebsd"))]
 type MsgControlLen = socklen_t;
 
 unsafe fn new_sockaddr_un(path: *const c_char) -> (sockaddr_un, usize) {


### PR DESCRIPTION
These changes are needed to compile ipc-channel on openbsd. ipc-channel itself is already compatible and no changes are needed. I've verified this with a project I'm working on that depends on this patch for openbsd support (the program itself has been tested on openbsd with a patched ipc-channel).