### PR TITLE
Enable backtraces on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: rust
 sudo: false
 
+env:
+  global:
+    - RUST_BACKTRACE=1
+
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,21 @@ sudo: false
 rust:
   - nightly
 
+os:
+  - linux
+  - osx
+
 env:
   global:
     - RUST_BACKTRACE=1
+  matrix:
+    - FEATURES="unstable"
+    - FEATURES="unstable force-inprocess"
 
 matrix:
   include:
     - os: linux
-      env: FEATURES="unstable"
-    - os: linux
-      env: FEATURES="unstable force-inprocess"
-    - os: linux
       env: FEATURES="unstable memfd"
-    - os: osx
-      env: FEATURES="unstable"
-    - os: osx
-      env: FEATURES="unstable force-inprocess"
 
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: rust
 sudo: false
 
+rust:
+  - nightly
+
 env:
   global:
     - RUST_BACKTRACE=1
@@ -8,19 +11,14 @@ env:
 matrix:
   include:
     - os: linux
-      rust: nightly
       env: FEATURES="unstable"
     - os: linux
-      rust: nightly
       env: FEATURES="unstable force-inprocess"
     - os: linux
-      rust: nightly
       env: FEATURES="unstable memfd"
     - os: osx
-      rust: nightly
       env: FEATURES="unstable"
     - os: osx
-      rust: nightly
       env: FEATURES="unstable force-inprocess"
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   PATH: '%PATH%;C:\Program Files (x86)\Rust\bin;C:\MinGW\bin'
+  RUST_BACKTRACE: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc


### PR DESCRIPTION
Make it easier to debug test failures caught by CI.

This also includes two extra commits refactoring `.travis.yml`, which are only related in that they touch the same code -- but since I now learned how the build matrix works, I can just as well do some tweaking while at it... And it's probably not worth the trouble to push this in a separate PR.