### PR TITLE
Use OOL transfers for macOS payloads.

### DIFF
--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -118,22 +118,35 @@ fn medium_data_with_sender_transfer() {
                (data, vec![], vec![]));
 }
 
-#[test]
-fn big_data() {
+fn check_big_data(size: u32) {
     let (tx, rx) = platform::channel().unwrap();
     let thread = thread::spawn(move || {
-        let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
+        let data: Vec<u8> = (0.. size).map(|i| (i % 251) as u8).collect();
         let data: &[u8] = &data[..];
         tx.send(data, vec![], vec![]).unwrap();
     });
     let (received_data, received_channels, received_shared_memory_regions) =
         rx.recv().unwrap();
-    let data: Vec<u8> = (0.. 1024 * 1024).map(|i| (i % 251) as u8).collect();
+    let data: Vec<u8> = (0.. size).map(|i| (i % 251) as u8).collect();
     let data: &[u8] = &data[..];
     assert_eq!(received_data.len(), data.len());
     assert_eq!((&received_data[..], received_channels, received_shared_memory_regions),
                (&data[..], vec![], vec![]));
     thread.join().unwrap();
+}
+
+#[test]
+fn big_data() {
+    check_big_data(1024 * 1024);
+}
+
+#[test]
+fn huge_data() {
+    check_big_data(1024 * 1024 * 50);
+    check_big_data(1024 * 1024 * 46);
+    check_big_data(1024 * 1024 * 49);
+    check_big_data(1024 * 1024 * 47);
+    check_big_data(1024 * 1024 * 48);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #98. This was much easier than figuring out how to calculate if a message would exceed the maximum limit, and all tests continue to pass.