### PR TITLE
Allow benchmarks to run to completion on macOS

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -428,3 +428,11 @@ fn test_reentrant() {
     sender.send(null.clone()).unwrap();
     assert_eq!(null, receiver.recv().unwrap());
 }
+
+#[test]
+fn transfer_closed_sender() {
+    let (main_tx, main_rx) = ipc::channel().unwrap();
+    let (transfer_tx, _) = ipc::channel::<()>().unwrap();
+    assert!(main_tx.send(transfer_tx).is_ok());
+    let _transferred_tx = main_rx.recv().unwrap();
+}


### PR DESCRIPTION
These commits fix a series of panics that I encountered while attempting to run benchmarks on macOS. The benchmarks now complete, as can be observed in #199.