### PR TITLE
Update uuid to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1"
 libc = "0.2.12"
 rand = "0.4"
 serde = { version="1.0", features=["rc"] }
-uuid = {version = "0.6", features = ["v4"]}
+uuid = {version = "0.7", features = ["v4"]}
 fnv = "1.0.3"
 tempfile = "3"
 


### PR DESCRIPTION
Updated uuid dependency from 0.6.* to 0.7.* 

Checked for usages in the codebase and no other changes are required. 