### PR TITLE
Use extracted shmemfdrs crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/servo/ipc-channel"
 
 [features]
 force-inprocess = []
-memfd = ["sc"]
+memfd = []
 unstable = []
 async = ["futures"]
 
@@ -23,10 +23,14 @@ uuid = {version = "0.7", features = ["v4"]}
 fnv = "1.0.3"
 tempfile = "3"
 
+[target.'cfg(all(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"), feature = "memfd"))'.dependencies]
+shmemfdrs = { version = "0.1.1", features = ["memfd"] }
+[target.'cfg(all(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"), not(feature = "memfd")))'.dependencies]
+shmemfdrs = { version = "0.1.1", features = [] }
+
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
 mio = "0.6.11"
 
-sc = { version = "0.2.2", optional = true }
 futures = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,10 @@ extern crate mio;
                                                 target_os = "openbsd",
                                                 target_os = "freebsd")))]
 extern crate fnv;
-#[cfg(all(feature = "memfd", not(feature = "force-inprocess"),
-          target_os="linux"))]
-#[macro_use]
-extern crate sc;
+#[cfg(any(target_os = "linux",
+          target_os = "openbsd",
+          target_os = "freebsd"))]
+extern crate shmemfdrs;
 
 #[cfg(feature = "async")]
 extern crate futures;


### PR DESCRIPTION
This crate has been extracted from ipc-channel[1] and provides exactly
the same `create_shmem()` function.  Additionally it supports SHM_OPEN for
FreeBSD, and has a test.

The sc crate has also been removed, but it is still used by shmemfdrs.

[1] https://github.com/Smithay/wayland-window/issues/14#issuecomment-350488570