### PR TITLE
Implement AsRawFd if possible

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -25,6 +25,7 @@ use std::mem;
 use std::ops::{Deref, RangeFrom};
 use std::ptr;
 use std::slice;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::time::UNIX_EPOCH;
@@ -108,6 +109,12 @@ impl Drop for OsIpcReceiver {
     }
 }
 
+impl AsRawFd for OsIpcReceiver {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.get()
+    }
+}
+
 impl OsIpcReceiver {
     fn from_fd(fd: c_int) -> OsIpcReceiver {
         OsIpcReceiver {
@@ -156,6 +163,12 @@ pub struct OsIpcSender {
     // (Rather, senders should just be cloned, as they are shared internally anyway --
     // another layer of sharing only adds unnecessary overhead...)
     nosync_marker: PhantomData<Cell<()>>,
+}
+
+impl AsRawFd for OsIpcSender {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd.0
+    }
 }
 
 impl OsIpcSender {

--- a/src/test.rs
+++ b/src/test.rs
@@ -437,3 +437,22 @@ fn transfer_closed_sender() {
     assert!(main_tx.send(transfer_tx).is_ok());
     let _transferred_tx = main_rx.recv().unwrap();
 }
+
+#[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
+                                                target_os = "openbsd",
+                                                target_os = "freebsd")))]
+#[test]
+fn test_as_raw_fd() {
+    use std::os::unix::io::AsRawFd;
+    let (tx, rx) = ipc::bytes_channel().unwrap();
+    let rx_fd = rx.as_raw_fd();
+    unsafe {
+        let flag = libc::fcntl(rx_fd, libc::F_GETFL);
+        assert!(flag & libc::O_RDWR != 0);
+    }
+    let tx_fd = tx.as_raw_fd();
+    unsafe {
+        let flag = libc::fcntl(tx_fd, libc::F_GETFL);
+        assert!(flag & libc::O_RDWR != 0);
+    }
+}


### PR DESCRIPTION
## Summary

On unix-like OSes implement `AsRawFd` on `IpcReceiver`, `IpcSender`,
`IpcBytesReceiver`, and `IpcBytesSender`.

## Drawbacks

This introduces some OS specific code in `src/ipc.rs` and you can really
cause problems with a channel given the raw fd.

Fixes: #214 