### PR TITLE
rustfmt: Start formatting code

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -197,8 +197,10 @@ mod ipc {
 
     fn bench_transfer_senders(b: &mut test::Bencher, count: usize) {
         let (main_tx, main_rx) = ipc::channel().unwrap();
-        let transfer_txs: Vec<_> = (0..count).map(|_| ipc::channel::<()>().unwrap())
-                                             .map(|(tx, _)| tx).collect();
+        let transfer_txs: Vec<_> = (0..count)
+            .map(|_| ipc::channel::<()>().unwrap())
+            .map(|(tx, _)| tx)
+            .collect();
         let mut transfer_txs = Some(transfer_txs);
         b.iter(|| {
             for _ in 0..ITERATIONS {
@@ -230,8 +232,10 @@ mod ipc {
 
     fn bench_transfer_receivers(b: &mut test::Bencher, count: usize) {
         let (main_tx, main_rx) = ipc::channel().unwrap();
-        let transfer_rxs: Vec<_> = (0..count).map(|_| ipc::channel::<()>().unwrap())
-                                             .map(|(_, rx)| rx).collect();
+        let transfer_rxs: Vec<_> = (0..count)
+            .map(|_| ipc::channel::<()>().unwrap())
+            .map(|(_, rx)| rx)
+            .collect();
         let mut transfer_rxs = Some(transfer_rxs);
         b.iter(|| {
             for _ in 0..ITERATIONS {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+match_block_trailing_comma = true
+match_arm_blocks = false
+binop_separator = "Back"
+reorder_imports = true
+# TODO(dlrobertson): gradually start formatting files
+ignore = [
+  "src/platform",
+  "src/ipc.rs"
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,28 +41,37 @@ extern crate crossbeam_channel;
 
 #[macro_use]
 extern crate lazy_static;
+#[cfg(all(
+    not(feature = "force-inprocess"),
+    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
+))]
+extern crate fnv;
 extern crate libc;
+#[cfg(all(
+    not(feature = "force-inprocess"),
+    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
+))]
+extern crate mio;
 extern crate rand;
 extern crate serde;
-#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios"))]
-extern crate uuid;
 extern crate tempfile;
-#[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                target_os = "openbsd",
-                                                target_os = "freebsd")))]
-extern crate mio;
-#[cfg(all(not(feature = "force-inprocess"), any(target_os = "linux",
-                                                target_os = "openbsd",
-                                                target_os = "freebsd")))]
-extern crate fnv;
-#[cfg(all(feature = "memfd", not(feature = "force-inprocess"),
-          target_os="linux"))]
+#[cfg(any(
+    feature = "force-inprocess",
+    target_os = "windows",
+    target_os = "android",
+    target_os = "ios"
+))]
+extern crate uuid;
+#[cfg(all(
+    feature = "memfd",
+    not(feature = "force-inprocess"),
+    target_os = "linux"
+))]
 #[macro_use]
 extern crate sc;
 
 #[cfg(feature = "async")]
 extern crate futures;
-
 
 pub mod ipc;
 pub mod platform;


### PR DESCRIPTION
 - Establish a basic rustfmt.toml and add ignore configuration for
   unformatted code.
 - Run `rustfmt` on the following
   - benches/bench.rs
   - src/lib.rs
   - src/router.rs
   - src/test.rs