### PR TITLE
fix: Build errors with async feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ serde = { version="1.0", features=["rc"] }
 uuid = {version = "0.7", features = ["v4"]}
 fnv = "1.0.3"
 tempfile = "3"
-futures-preview = { version = "0.3.0-alpha", optional = true }
-futures-test-preview = { version = "0.3.0-alpha", optional = true }
+futures-preview = { version = "0.3.0-alpha.17", optional = true }
+futures-test-preview = { version = "0.3.0-alpha.17", optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
 mio = "0.6.11"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -20,7 +20,7 @@ mod platform {
     use ipc_channel::platform;
 
     use std::sync::{mpsc, Mutex};
-    use test;
+    use crate::test;
 
     #[bench]
     fn create_channel(b: &mut test::Bencher) {
@@ -182,7 +182,7 @@ mod ipc {
     use crate::ITERATIONS;
     use ipc_channel::ipc;
 
-    use test;
+    use crate::test;
 
     #[bench]
     fn transfer_empty(b: &mut test::Bencher) {
@@ -269,7 +269,7 @@ mod ipc {
         use crate::ITERATIONS;
         use ipc_channel::ipc::{self, IpcReceiverSet};
 
-        use test;
+        use crate::test;
 
         // Benchmark selecting over a set of `n` receivers,
         // with `to_send` of them actually having pending data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 #![cfg_attr(all(feature = "unstable", test), feature(specialization))]
-#![cfg_attr(feature = "async", feature(futures_api))]
 
 //! An implementation of the Rust channel API over process boundaries. Under the
 //! hood, this API uses Mach ports on Mac and file descriptor passing over Unix


### PR DESCRIPTION
This PR fixes a few build errors to make the async feature usable in 1.36 or nightly.

The `futures_api` feature is now stable in 1.36, so the flag can be removed.
And some other very minor typing fixes.
