### PR TITLE
Update dependencies and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.12.2"
+version = "0.13.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"
@@ -15,7 +15,7 @@ async = ["futures-preview", "futures-test-preview"]
 
 [dependencies]
 bincode = "1"
-crossbeam-channel = "0.3"
+crossbeam-channel = "0.4"
 fnv = "1.0.3"
 futures-preview = { version = "0.3.0-alpha.17", optional = true }
 futures-test-preview = { version = "0.3.0-alpha.17", optional = true }
@@ -31,4 +31,4 @@ mio = "0.6.11"
 sc = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
-crossbeam = "0.2"
+crossbeam-utils = "0.7"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -14,7 +14,7 @@ extern crate test;
 const ITERATIONS: usize = 1;
 
 mod platform {
-    extern crate crossbeam;
+    extern crate crossbeam_utils;
 
     use crate::ITERATIONS;
     use ipc_channel::platform;
@@ -40,9 +40,9 @@ mod platform {
 
         if size > platform::OsIpcSender::get_max_fragment_size() {
             b.iter(|| {
-                crossbeam::scope(|scope| {
+                crossbeam_utils::thread::scope(|scope| {
                     let tx = tx.clone();
-                    scope.spawn(|| {
+                    scope.spawn(|_| {
                         let wait_rx = wait_rx.lock().unwrap();
                         let tx = tx;
                         for _ in 0..ITERATIONS {


### PR DESCRIPTION
Unfortunately crossbeam-channel is in the public API of `RouterProxy` so
updating it is a breaking change.