### PR TITLE
Add more useful return type to try_recv API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.13.0"
+version = "0.14.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::ipc;
 use self::mach_sys::{kern_return_t, mach_msg_body_t, mach_msg_header_t, mach_msg_return_t};
 use self::mach_sys::{mach_msg_ool_descriptor_t, mach_msg_port_descriptor_t, mach_msg_type_name_t};
 use self::mach_sys::{mach_msg_timeout_t, mach_port_limits_t, mach_port_msgcount_t};
@@ -1081,6 +1082,25 @@ impl From<mach_msg_return_t> for MachError {
 impl From<KernelError> for MachError {
     fn from(kernel_error: KernelError) -> MachError {
         MachError::Kernel(kernel_error)
+    }
+}
+
+impl From<MachError> for ipc::TryRecvError {
+    fn from(error: MachError) -> Self {
+        match error {
+            MachError::NotifyNoSenders => ipc::TryRecvError::IpcError(ipc::IpcError::Disconnected),
+            MachError::RcvTimedOut => ipc::TryRecvError::Empty,
+            e => ipc::TryRecvError::IpcError(ipc::IpcError::Io(Error::from(e))),
+        }
+    }
+}
+
+impl From<MachError> for ipc::IpcError {
+    fn from(error: MachError) -> Self {
+        match error {
+            MachError::NotifyNoSenders => ipc::IpcError::Disconnected,
+            e => ipc::IpcError::Io(Error::from(e)),
+        }
     }
 }
 


### PR DESCRIPTION
This avoids breaking any code that currently relies on `is_err()` being true for both an IPC receiver that has no messages pending and no senders available. For code that does care about that distinction, it is now possible to match on the new enum to distinguish the cases, and we now avoid boxing a new error value in the common case that there are no messages pending.

Fixes #254.