### PR TITLE
Clarify crate docs re: kernel version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! ## `memfd`
 //!
 //! Use [memfd_create] to back [OsIpcSharedMemory] on Linux. [memfd_create] was
-//! introduced in version 3.17. __WARNING:__ Enabling this feature with kernel
+//! introduced in kernel version 3.17. __WARNING:__ Enabling this feature with kernel
 //! version less than 3.17 will cause panics on any use of [IpcSharedMemory].
 //!
 //! ## `unstable`


### PR DESCRIPTION
I was briefly confused here because it was not clear whether this was version 3.17 of this crate or something else.