### PR TITLE
Make it compile for wasm32-unknown-unknown and wasm32-wasi

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -25,9 +25,15 @@ mod os {
     pub use super::macos::*;
 }
 
-#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios"))]
+#[cfg(any(
+    feature = "force-inprocess",
+    target_os = "windows", target_os = "android", target_os = "ios", target_os = "wasi", target_os = "unknown"
+))]
 mod inprocess;
-#[cfg(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios"))]
+#[cfg(any(
+    feature = "force-inprocess",
+    target_os = "windows", target_os = "android", target_os = "ios", target_os = "wasi", target_os = "unknown"
+))]
 mod os {
     pub use super::inprocess::*;
 }


### PR DESCRIPTION
This uses the "inprocess" implementation for the WebAssembly targets, like Windows, Android and iOS already do.

Note that this only compile with the master branch of the `uuid` crate, as https://github.com/uuid-rs/uuid/pull/477 hasn't been published yet.
