### PR TITLE
unix: always set FD_CLOEXEC on Linux

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -44,6 +44,17 @@ const SCM_RIGHTS: c_int = 0x01;
 // Empirically, we have to deduct 32 bytes from that.
 const RESERVED_SIZE: usize = 32;
 
+#[cfg(target_os = "linux")]
+const SOCK_FLAGS: c_int = libc::SOCK_CLOEXEC;
+#[cfg(not(target_os = "linux"))]
+const SOCK_FLAGS: c_int = 0;
+
+#[cfg(target_os = "linux")]
+const RECVMSG_FLAGS: c_int = libc::MSG_CMSG_CLOEXEC;
+#[cfg(not(target_os = "linux"))]
+const RECVMSG_FLAGS: c_int = 0;
+
+
 #[cfg(target_env = "gnu")]
 type IovLen = usize;
 #[cfg(target_env = "gnu")]
@@ -80,7 +91,7 @@ static SHM_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub fn channel() -> Result<(OsIpcSender, OsIpcReceiver),UnixError> {
     let mut results = [0, 0];
     unsafe {
-        if socketpair(libc::AF_UNIX, SOCK_SEQPACKET, 0, &mut results[0]) >= 0 {
+        if socketpair(libc::AF_UNIX, SOCK_SEQPACKET | SOCK_FLAGS, 0, &mut results[0]) >= 0 {
             Ok((OsIpcSender::from_fd(results[0]), OsIpcReceiver::from_fd(results[1])))
         } else {
             Err(UnixError::last())
@@ -394,7 +405,7 @@ impl OsIpcSender {
     pub fn connect(name: String) -> Result<OsIpcSender,UnixError> {
         let name = CString::new(name).unwrap();
         unsafe {
-            let fd = libc::socket(libc::AF_UNIX, SOCK_SEQPACKET, 0);
+            let fd = libc::socket(libc::AF_UNIX, SOCK_SEQPACKET | SOCK_FLAGS, 0);
             let (sockaddr, len) = new_sockaddr_un(name.as_ptr());
             if libc::connect(fd, &sockaddr as *const _ as *const sockaddr, len as socklen_t) < 0 {
                 return Err(UnixError::last())
@@ -590,7 +601,7 @@ impl Drop for OsIpcOneShotServer {
 impl OsIpcOneShotServer {
     pub fn new() -> Result<(OsIpcOneShotServer, String),UnixError> {
         unsafe {
-            let fd = libc::socket(libc::AF_UNIX, SOCK_SEQPACKET, 0);
+            let fd = libc::socket(libc::AF_UNIX, SOCK_SEQPACKET | SOCK_FLAGS, 0);
             let temp_dir = Builder::new().tempdir().unwrap();
             let socket_path = temp_dir.path().join("socket");
             let path_string = socket_path.to_str().unwrap();
@@ -997,7 +1008,7 @@ fn create_shmem(name: CString, length: usize) -> c_int {
 #[cfg(all(feature="memfd", target_os="linux"))]
 fn create_shmem(name: CString, length: usize) -> c_int {
     unsafe {
-        let fd = memfd_create(name.as_ptr(), 0);
+        let fd = memfd_create(name.as_ptr(), libc::MFD_CLOEXEC as usize);
         assert!(fd >= 0);
         assert!(libc::ftruncate(fd, length as off_t) == 0);
         fd
@@ -1037,7 +1048,7 @@ impl UnixCmsg {
             }
         }
 
-        let result = recvmsg(fd, &mut self.msghdr, 0);
+        let result = recvmsg(fd, &mut self.msghdr, RECVMSG_FLAGS);
         let result = if result > 0 {
             Ok(result as usize)
         } else if result == 0 {


### PR DESCRIPTION
Always set FD_CLOEXEC to avoid child processes accidentally inheriting
file descriptors.

As none of the structs of ipc-channel allow extracting the underlying
file descriptors, there is no sane way to recover these FDs after an
exec anyways, so we don't need to make this configurable and just set
it unconditionally.

For now only Linux is covered, as special flags are available for all
relevant functions that set FD_CLOEXEC atomically, avoiding race
conditions in multithreaded processes:

- SOCK_CLOEXEC is passed to socket() and socketpair()
  - Supported since kernel 2.6.27
- MSG_CMSG_CLOEXEC is passed to recvmsg()
  - Supported since kernel 2.6.23
- MFD_CLOEXEC is passed to memfd_create()
- shmem_open() always sets FD_CLOEXEC according to POSIX

In libc, SOCK_CLOEXEC and MSG_CMSG_CLOEXEC are defined for FreeBSD and OpenBSD as well, so it's possible the restriction to `target_os = "linux"` is unnecessary after all, but I can't easily test on those OS.

This was previously discussed in #214.