### PR TITLE
Windows (rebased and updated)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,19 @@ rust:
 
 os:
   - linux
+  - osx
 
 env:
   global:
     - RUST_BACKTRACE=1
   matrix:
     - FEATURES="unstable"
+    - FEATURES="unstable force-inprocess"
+
+matrix:
+  include:
+    - os: linux
+      env: FEATURES="unstable memfd"
 
 script:
   - cargo build --features "$FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - RUST_BACKTRACE=1
   matrix:
     - FEATURES="unstable"
-    - FEATURES="unstable memfd"
 
 script:
   - cargo build --features "$FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - RUST_BACKTRACE=1
   matrix:
     - FEATURES="unstable"
+    - FEATURES="unstable memfd"
 
 script:
   - cargo build --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ memfd = ["sc"]
 unstable = []
 async = ["futures-preview", "futures-test-preview"]
 win32-trace = []
+windows-shared-memory-equality = []
 
 [dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.14.1"
+version = "0.15.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,4 @@ sc = { version = "0.2.2", optional = true }
 crossbeam-utils = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = {version = "0.3.7", features = ["ioapiset", "memoryapi", "namedpipeapi", "handleapi"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ sc = { version = "0.2.2", optional = true }
 crossbeam-utils = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = {version = "0.3.7", features = ["ioapiset", "memoryapi", "namedpipeapi", "handleapi"]}
+winapi = {version = "0.3.7", features = ["minwindef", "ioapiset", "memoryapi", "namedpipeapi", "handleapi", "fileapi", "impl-default"]}

--- a/README.md
+++ b/README.md
@@ -21,5 +21,3 @@ In order to bootstrap an IPC connection across processes, you create an instance
 ## Major missing features
 
 * Servers only accept one client at a time. This is fine if you simply want to use this API to split your application up into a fixed number of mutually untrusting processes, but it's not suitable for implementing a system service. An API for multiple clients may be added later if demand exists for it.
-
-* No Windows support exists yet. The right way to implement this will likely be with named pipes and `DuplicateHandle`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
   RUST_BACKTRACE: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    FEATURES: "unstable"
+    FEATURES: "unstable,windows-shared-memory-equality"
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,17 @@ environment:
   RUST_BACKTRACE: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    FEATURES: "unstable,windows-shared-memory-equality"
+    FEATURES: "unstable"
+  - TARGET: i686-pc-windows-msvc
+    FEATURES: "unstable"
+  - TARGET: i686-pc-windows-gnu
+    FEATURES: "unstable"
+  - TARGET: x86_64-pc-windows-msvc
+    FEATURES: "unstable force-inprocess"
+  - TARGET: i686-pc-windows-msvc
+    FEATURES: "unstable force-inprocess"
+  - TARGET: i686-pc-windows-gnu
+    FEATURES: "unstable force-inprocess"
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,12 @@ environment:
     FEATURES: "unstable force-inprocess"
   - TARGET: i686-pc-windows-gnu
     FEATURES: "unstable force-inprocess"
+  - TARGET: x86_64-pc-windows-msvc
+    FEATURES: "unstable windows-shared-memory-equality"
+  - TARGET: i686-pc-windows-msvc
+    FEATURES: "unstable windows-shared-memory-equality"
+  - TARGET: i686-pc-windows-gnu
+    FEATURES: "unstable windows-shared-memory-equality"
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -456,7 +456,8 @@ impl IpcReceiverSet {
 /// # let rx_shmem = rx.recv().unwrap();
 /// # assert_eq!(shmem, rx_shmem);
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
+#[cfg_attr(any(not(target_os = "windows"), all(target_os = "windows", feature = "windows-shared-memory-equality")), derive(PartialEq))]
 pub struct IpcSharedMemory {
     os_shared_memory: OsIpcSharedMemory,
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -454,6 +454,7 @@ impl IpcReceiverSet {
 /// let shmem = IpcSharedMemory::from_bytes(&data);
 /// tx.send(shmem.clone()).unwrap();
 /// # let rx_shmem = rx.recv().unwrap();
+/// # #[cfg(any(not(target_os = "windows"), all(target_os = "windows", feature = "windows-shared-memory-equality")))]
 /// # assert_eq!(shmem, rx_shmem);
 /// ```
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,7 @@ pub mod asynch;
 
 #[cfg(all(not(feature = "force-inprocess"), target_os = "windows"))]
 extern crate winapi;
-#[cfg(all(not(feature = "force-inprocess"), target_os = "windows"))]
-extern crate kernel32;
+
 
 pub mod ipc;
 pub mod platform;

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -20,17 +20,12 @@ use crate::platform::{OsIpcSender, OsIpcOneShotServer};
 #[cfg(not(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios")))]
 use libc::{kill, SIGSTOP, SIGCONT};
 #[cfg(not(any(feature = "force-inprocess", target_os = "windows", target_os = "android", target_os = "ios")))]
-<<<<<<< HEAD
 use crate::test::{fork, Wait};
 
 // Helper to get a channel_name argument passed in; used for the
 // cross-process spawn server tests.
 #[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios")))]
-=======
-use test::{fork, Wait};
-#[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios")))]
->>>>>>> Implement ipc-channel on Windows
-use test::{get_channel_name_arg, spawn_server};
+use crate::test::{get_channel_name_arg, spawn_server};
 
 #[test]
 fn simple() {
@@ -198,15 +193,9 @@ fn with_n_fds(n: usize, size: usize) {
     let (super_tx, super_rx) = platform::channel().unwrap();
 
     let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-    let thread = {
-        let data = data.clone();
-        thread::spawn(move || {
-            super_tx.send(&data[..], sender_fds, vec![]).unwrap();
-        })
-    };
+    super_tx.send(&data[..], sender_fds, vec![]).unwrap();
     let (received_data, received_channels, received_shared_memory_regions) =
         super_rx.recv().unwrap();
-    thread.join().unwrap();
 
     assert_eq!(received_data.len(), data.len());
     assert_eq!(&received_data[..], &data[..]);

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -7,6 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Most of this file won't compile without `windows-shared-memory-equality` feature on Windows since `PartialEq` won't be implemented for `IpcSharedMemory`.
+#![cfg(any(not(target_os = "windows"), all(target_os = "windows", feature = "windows-shared-memory-equality")))]
+
 use crate::platform::{self, OsIpcChannel, OsIpcReceiverSet};
 use crate::platform::{OsIpcSharedMemory};
 use std::collections::HashMap;

--- a/src/platform/windows/aliased_cell.rs
+++ b/src/platform/windows/aliased_cell.rs
@@ -1,0 +1,363 @@
+// Copyright 2018 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::mem::{self, ManuallyDrop};
+use std::thread;
+
+/// Dummy type that panics when its destructor is invoked.
+#[derive(Debug)]
+struct DropBomb();
+
+impl Drop for DropBomb {
+    fn drop(&mut self) {
+        let message = "Trying to drop an AliasedCell, which may still have aliases outstanding.";
+        if thread::panicking() {
+            eprintln!("{}", message);
+        } else {
+            panic!(message);
+        }
+    }
+}
+
+/// A wrapper for unsafely aliased memory locations.
+///
+/// `AliasedCell' makes sure that its inner value
+/// is completely inaccessible from safe code.
+/// Once an `AliasedCell` has been constructed from some value,
+/// until the value is moved out again with the (unsafe) `into_inner()` method,
+/// the only way to access the wrapped value
+/// is through the unsafe `alias_mut()` method.
+///
+/// This is useful for FFI calls that take raw pointers as input,
+/// and hold on to them even after returning control to the caller.
+/// Since Rust's type system is not aware of such aliases,
+/// it cannot provide the usual guarantees about validity of pointers
+/// and exclusiveness of mutable pointers.
+/// This means that any code that has access to the memory in question
+/// is inherently unsafe as long as such untracked aliases exist.
+/// Putting the value in an `AliasedCell` before the FFI call,
+/// and only taking it out again
+/// once the caller has ensured that all aliases have been dropped
+/// (most likely through another FFI call),
+/// makes certain that any such unsafe access to the aliased value
+/// can only happen from code marked as `unsafe`.
+///
+/// An `AliasedCell` should never be simply dropped in normal use.
+/// Rather, it should always be freed explicitly with `into_inner()`,
+/// signalling that there are no outstanding aliases anymore.
+/// When an `AliasedCell` is dropped unexpectedly,
+/// we have to assume that it likely still has untracked aliases,
+/// and thus freeing the memory would probably be unsound.
+/// Therefore, the `drop()` implementation of `AliasedCell`
+/// leaks the inner value instead of freeing it;
+/// and throws a panic.
+/// Leaking the memory, while undesirable in general,
+/// keeps the memory accessible to any outstanding aliases.
+/// This is the only way to retain soundness during unwinding,
+/// or when the panic gets catched.
+///
+/// Note that making FFI access through untracked aliases
+/// requires the value to have a stable memory location --
+/// typically by living on the heap rather than on the stack.
+/// If the value isn't already in a heap-allocated container
+/// such as `Box<>`, `Vec<>`, or `String`,
+/// it is the caller's responsibility to wrap it in a `Box<>` explicitly.
+/// `AliasedCell` itself cannot ensure that the address remains stable
+/// when the `AliasedCell` gets moved around.
+#[derive(Debug)]
+pub struct AliasedCell<T> {
+    value: ManuallyDrop<T>,
+    drop_bomb: DropBomb,
+}
+
+impl<T> AliasedCell<T> {
+    /// Wrap the provided value in an `AliasedCell`, making it inaccessible from safe code.
+    pub fn new(value: T) -> AliasedCell<T> {
+        AliasedCell {
+            value: ManuallyDrop::new(value),
+            drop_bomb: DropBomb(),
+        }
+    }
+
+    /// Get a pointer to the inner value.
+    ///
+    /// Note that this yields a regular reference.
+    /// To actually get an untracked alias,
+    /// it needs to be cast or coerced into a raw pointer.
+    /// This usually happens implicitly though
+    /// when calling an FFI function (or any other function)
+    /// taking a raw pointer as argument.
+    ///
+    /// `alias_mut()` can be called any number of times:
+    /// the wrapper doesn't keep track of the number of outstanding aliases --
+    /// the caller is responsible for making sure that no aliases are left
+    /// before invoking `into_inner()`.
+    /// If you need to track the number of aliases,
+    /// wrap the inner value in an `Rc<>` or `Arc` --
+    /// this way, the reference count will also be inaccessible from safe code.
+    pub unsafe fn alias_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+
+    /// Move out the wrapped value, making it accessible from safe code again.
+    pub unsafe fn into_inner(self) -> T {
+        mem::forget(self.drop_bomb);
+        ManuallyDrop::into_inner(self.value)
+    }
+}
+
+/// Some basic tests.
+///
+/// Note: These mostly just check that various expected usage scenarios
+/// can be compiled and basically work.
+/// We can't verify though that the usage is actually sound;
+/// nor do we check whether invalid usage is indeed prevented by the compiler...
+///
+/// (The latter could probably be remedied though
+/// with some sort of compile-fail tests.)
+#[cfg(test)]
+mod tests {
+    use super::AliasedCell;
+
+    unsafe fn mutate_value(addr: *mut [i32; 4]) {
+        let value = addr.as_mut().unwrap();
+        value[1] += value[3];
+    }
+
+    struct Mutator {
+        addr: *mut [i32; 4],
+        ascended: bool,
+    }
+
+    impl Mutator {
+        unsafe fn new(addr: *mut [i32; 4]) -> Mutator {
+            Mutator {
+                addr: addr,
+                ascended: false,
+            }
+        }
+
+        fn ascend(&mut self) {
+            self.ascended = true;
+        }
+
+        unsafe fn mutate(&mut self) {
+            let value = self.addr.as_mut().unwrap();
+            if self.ascended {
+                value[3] += value[2];
+            } else {
+                value[1] += value[3];
+            }
+        }
+    }
+
+    #[test]
+    fn noop_roundtrip() {
+        let value = [1, 3, 3, 7];
+        let cell = AliasedCell::new(Box::new(value));
+        let new_value = unsafe {
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 3, 3, 7]);
+    }
+
+    #[test]
+    fn unused_alias() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        unsafe {
+            cell.alias_mut().as_mut();
+        }
+        let new_value = unsafe {
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 3, 3, 7]);
+    }
+
+    #[test]
+    fn mutate() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        unsafe {
+            mutate_value(cell.alias_mut().as_mut());
+        }
+        let new_value = unsafe {
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 10, 3, 7]);
+    }
+
+    /// Verify that we can take multiple aliases.
+    #[test]
+    fn mutate_twice() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        unsafe {
+            mutate_value(cell.alias_mut().as_mut());
+        }
+        unsafe {
+            mutate_value(cell.alias_mut().as_mut());
+        }
+        let new_value = unsafe {
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 17, 3, 7]);
+    }
+
+    /// Verify that we can do basic safe manipulations between unsafe blocks.
+    #[test]
+    fn moves() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        unsafe {
+            mutate_value(cell.alias_mut().as_mut());
+        }
+        let mut cell2 = cell;
+        unsafe {
+            mutate_value(cell2.alias_mut().as_mut());
+        }
+        let cell3 = cell2;
+        let new_value = unsafe {
+            *cell3.into_inner()
+        };
+        assert_eq!(new_value, [1, 17, 3, 7]);
+    }
+
+    /// Verify that alias can be used at a later point.
+    #[test]
+    fn mutate_deferred() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        let mut mutator = unsafe {
+            Mutator::new(cell.alias_mut().as_mut())
+        };
+        unsafe {
+            mutator.mutate();
+        }
+        let new_value = unsafe {
+            drop(mutator);
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 10, 3, 7]);
+    }
+
+    #[test]
+    fn mutate_deferred_twice() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        let mut mutator = unsafe {
+            Mutator::new(cell.alias_mut().as_mut())
+        };
+        unsafe {
+            mutator.mutate();
+        }
+        unsafe {
+            mutator.mutate();
+        }
+        let new_value = unsafe {
+            drop(mutator);
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 17, 3, 7]);
+    }
+
+    /// Further safe manipulations.
+    #[test]
+    fn deferred_moves() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        let mutator = unsafe {
+            Mutator::new(cell.alias_mut().as_mut())
+        };
+        let cell2 = cell;
+        let mut mutator2 = mutator;
+        unsafe {
+            mutator2.mutate();
+        }
+        let cell3 = cell2;
+        let mutator3 = mutator2;
+        let new_value = unsafe {
+            drop(mutator3);
+            *cell3.into_inner()
+        };
+        assert_eq!(new_value, [1, 10, 3, 7]);
+    }
+
+    /// Non-trivial safe manipulation.
+    #[test]
+    fn safe_frobbing() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        let mut mutator = unsafe {
+            Mutator::new(cell.alias_mut().as_mut())
+        };
+        unsafe {
+            mutator.mutate();
+        }
+        mutator.ascend();
+        unsafe {
+            mutator.mutate();
+        }
+        let new_value = unsafe {
+            drop(mutator);
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 10, 3, 10]);
+    }
+
+    /// Verify that two aliases can exist simultaneously.
+    #[test]
+    fn two_mutators() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        let mut mutator1 = unsafe {
+            Mutator::new(cell.alias_mut().as_mut())
+        };
+        unsafe {
+            mutator1.mutate();
+        }
+        let mut mutator2 = unsafe {
+            Mutator::new(cell.alias_mut().as_mut())
+        };
+        unsafe {
+            mutator2.mutate();
+        }
+        let new_value = unsafe {
+            drop(mutator1);
+            drop(mutator2);
+            *cell.into_inner()
+        };
+        assert_eq!(new_value, [1, 17, 3, 7]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Trying to drop an AliasedCell, which may still have aliases outstanding.")]
+    fn invalid_drop() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        unsafe {
+            let mut mutator = Mutator::new(cell.alias_mut().as_mut());
+            mutator.mutate();
+            drop(cell);
+        }
+    }
+
+    /// Verify that we skip the panic-on-drop while unwinding from another panic.
+    #[test]
+    #[should_panic(expected = "bye!")]
+    fn panic() {
+        let value = [1, 3, 3, 7];
+        let mut cell = AliasedCell::new(Box::new(value));
+        unsafe {
+            let mut mutator = Mutator::new(cell.alias_mut().as_mut());
+            mutator.mutate();
+            panic!("bye!");
+        }
+    }
+}

--- a/src/platform/windows/aliased_cell.rs
+++ b/src/platform/windows/aliased_cell.rs
@@ -115,7 +115,7 @@ impl<T> AliasedCell<T> {
     /// while the data might actually be mutated elsewhere
     /// through some outstanding mutable aliases.
     pub unsafe fn alias(&self) -> &T {
-        &self.inner
+        &self.value // orig &self.inner
     }
 
     /// Move out the wrapped value, making it accessible from safe code again.

--- a/src/platform/windows/aliased_cell.rs
+++ b/src/platform/windows/aliased_cell.rs
@@ -105,6 +105,19 @@ impl<T> AliasedCell<T> {
         &mut self.value
     }
 
+    /// Get a shared (immutable) pointer to the inner value.
+    ///
+    /// With this method it's possible to get an alias
+    /// while only holding a shared reference to the `AliasedCell`.
+    ///
+    /// Since all the unsafe aliases are untracked,
+    /// it's up to the callers to make sure no shared aliases are used
+    /// while the data might actually be mutated elsewhere
+    /// through some outstanding mutable aliases.
+    pub unsafe fn alias(&self) -> &T {
+        &self.inner
+    }
+
     /// Move out the wrapped value, making it accessible from safe code again.
     pub unsafe fn into_inner(self) -> T {
         mem::forget(self.drop_bomb);

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -938,6 +938,8 @@ impl OsIpcReceiver {
         unsafe {
             let reader_borrow = self.reader.borrow();
             let handle = *reader_borrow.handle;
+            // Boxing this to get a stable address is not strictly necesssary here,
+            // since we are not moving the local variable around -- but better safe than sorry...
             let mut ov = Box::new(mem::zeroed::<winapi::OVERLAPPED>());
             let ok = kernel32::ConnectNamedPipe(handle, ov.deref_mut());
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1366,8 +1366,8 @@ impl OsIpcReceiverSet {
                 }
             }
 
-            if remove_index.is_some() {
-                self.readers.swap_remove(remove_index.unwrap());
+            if let Some(index) = remove_index {
+                self.readers.swap_remove(index);
             }
 
             // if we didn't dequeue at least one complete message -- we need to loop through GetQueuedCS again;

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -714,8 +714,9 @@ impl MessageReader {
 
         self.entry_id = Some(entry_id);
 
-        // Make sure that the reader has a read in flight,
-        // otherwise a later select() will hang.
+        // The readers in the IOCP need to have async reads in flight,
+        // so they can actually get completion events --
+        // otherwise, a subsequent `select()` call would just hang indefinitely.
         self.start_read()
     }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1270,12 +1270,12 @@ impl OsIpcReceiverSet {
             let mut io_err = winapi::ERROR_SUCCESS;
 
             let reader_index = unsafe {
-                let mut completion_key: HANDLE = INVALID_HANDLE_VALUE;
+                let mut completion_key = INVALID_HANDLE_VALUE as winapi::ULONG_PTR;
                 let mut ov_ptr: *mut winapi::OVERLAPPED = ptr::null_mut();
                 // XXX use GetQueuedCompletionStatusEx to dequeue multiple CP at once!
                 let ok = kernel32::GetQueuedCompletionStatus(self.iocp.as_raw(),
                                                              &mut nbytes,
-                                                             &mut completion_key as *mut _ as *mut winapi::ULONG_PTR,
+                                                             &mut completion_key,
                                                              &mut ov_ptr,
                                                              winapi::INFINITE);
                 win32_trace!("[# {:?}] GetQueuedCS -> ok:{} nbytes:{} key:{:?}", self.iocp.as_raw(), ok, nbytes, completion_key);
@@ -1292,11 +1292,11 @@ impl OsIpcReceiverSet {
                 }
 
                 assert!(!ov_ptr.is_null());
-                assert!(completion_key != INVALID_HANDLE_VALUE);
+                assert!(completion_key != INVALID_HANDLE_VALUE as winapi::ULONG_PTR);
 
                 // Find the matching receiver
                 let (index, _) = self.readers.iter().enumerate()
-                                 .find(|&(_, ref reader)| reader.handle.as_raw() == completion_key)
+                                 .find(|&(_, ref reader)| reader.handle.as_raw() as winapi::ULONG_PTR == completion_key)
                                  .expect("Windows IPC ReceiverSet got notification for a receiver it doesn't know about");
                 index
             };

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1630,7 +1630,10 @@ impl From<WinError> for Error {
     fn from(error: WinError) -> Error {
         match error {
             WinError::ChannelClosed => {
-                Error::new(ErrorKind::BrokenPipe, "Win channel closed")
+                // This is the error code we originally got from the Windows API
+                // to signal the "channel closed" (no sender) condition --
+                // so hand it back to the Windows API to create an appropriate `Error` value.
+                Error::from_raw_os_error(winapi::ERROR_BROKEN_PIPE as i32)
             },
             WinError::NoData => {
                 Error::new(ErrorKind::WouldBlock, "Win channel has no data available")

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -718,56 +718,25 @@ impl MessageReader {
     fn read_raw_sized(mut self, size: usize) -> Result<Vec<u8>,WinError> {
         assert!(self.read_buf.len() == 0);
 
-        // We use with_capacity() to allocate an uninitialized buffer,
-        // since we're going to read into it and don't need to
-        // zero it.
-        let mut buf = Vec::with_capacity(size);
-        while buf.len() < size {
+        self.read_buf.reserve(size);
+        while self.read_buf.len() < size {
             // Because our handle is asynchronous, we have to do a two-part read --
             // first issue the operation, then wait for its completion.
             unsafe {
-                let ov = self.ov.deref_mut();
-                *ov = mem::zeroed();
-
-                // Temporarily extend the vector to span its entire capacity,
-                // so we can safely sub-slice it for the actual read.
-                let buf_len = buf.len();
-                let buf_cap = buf.capacity();
-                buf.set_len(buf_cap);
-
-                let mut bytes_read: u32 = 0;
-                let ok = {
-                    let remaining_buf = &mut buf[buf_len..];
-                    kernel32::ReadFile(*self.handle,
-                                       remaining_buf.as_mut_ptr() as LPVOID,
-                                       remaining_buf.len() as u32,
-                                       &mut bytes_read,
-                                       ov)
-                };
-
-                // Restore the original size before error handling,
-                // so we never leave the function with the buffer exposing uninitialized data.
-                buf.set_len(buf_len);
-
-                if ok == winapi::FALSE && GetLastError() != winapi::ERROR_IO_PENDING {
-                    return Err(WinError::last("ReadFile"));
+                try!(self.start_read());
+                // Sender should not close until it sent as much data as we expect...
+                if self.closed {
+                    return Err(WinError::from_system(winapi::ERROR_BROKEN_PIPE, "ReadFile"));
                 }
-
-                if ov.Internal as i32 == winapi::STATUS_PENDING {
-                    let ok = kernel32::GetOverlappedResult(*self.handle, ov, &mut bytes_read, winapi::TRUE);
-                    if ok == winapi::FALSE {
-                        return Err(WinError::last("GetOverlappedResult"));
-                    }
-                } else {
-                    bytes_read = ov.InternalHigh as u32;
+                // In blocking mode, this should never fail...
+                self.fetch_async_result(BlockingMode::Blocking).unwrap();
+                if self.closed {
+                    return Err(WinError::from_system(winapi::ERROR_BROKEN_PIPE, "ReadFile"));
                 }
-
-                let new_len = buf_len + bytes_read as usize;
-                buf.set_len(new_len);
             }
         }
 
-        Ok(buf)
+        Ok(mem::replace(&mut self.read_buf, vec![]))
     }
 }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1266,10 +1266,10 @@ impl OsIpcReceiverSet {
         // Do this in a loop, because we may need to dequeue multiple packets to
         // read a complete message.
         while selection_results.is_empty() {
-            let mut nbytes: u32 = 0;
             let mut io_err = winapi::ERROR_SUCCESS;
 
             let reader_index = unsafe {
+                let mut nbytes: u32 = 0;
                 let mut completion_key = INVALID_HANDLE_VALUE as winapi::ULONG_PTR;
                 let mut ov_ptr: *mut winapi::OVERLAPPED = ptr::null_mut();
                 // XXX use GetQueuedCompletionStatusEx to dequeue multiple CP at once!

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -683,12 +683,12 @@ impl MessageReader {
         Ok(result)
     }
 
-    fn add_to_iocp(&mut self, iocp: HANDLE, set_id: u64) -> Result<(),WinError> {
+    fn add_to_iocp(&mut self, iocp: &WinHandle, set_id: u64) -> Result<(),WinError> {
         unsafe {
             assert!(self.set_id.is_none());
 
             let ret = kernel32::CreateIoCompletionPort(*self.handle,
-                                                       iocp,
+                                                       **iocp,
                                                        *self.handle as winapi::ULONG_PTR,
                                                        0);
             if ret.is_null() {
@@ -1244,7 +1244,7 @@ impl OsIpcReceiverSet {
         let mut reader = receiver.reader.into_inner();
 
         let set_id = self.incrementor.next().unwrap();
-        try!(reader.add_to_iocp(*self.iocp, set_id));
+        try!(reader.add_to_iocp(&self.iocp, set_id));
 
         win32_trace!("[# {:?}] ReceiverSet add {:?}, id {}", *self.iocp, *reader.handle, set_id);
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1282,14 +1282,9 @@ impl OsIpcReceiverSet {
             }
         });
 
-        // if we had prematurely closed elements, just process them first
-        if !selection_results.is_empty() {
-            return Ok(selection_results);
-        }
-
         // Do this in a loop, because we may need to dequeue multiple packets to
         // read a complete message.
-        loop {
+        while selection_results.is_empty() {
             let mut nbytes: u32 = 0;
             let mut io_err = winapi::ERROR_SUCCESS;
 
@@ -1376,12 +1371,6 @@ impl OsIpcReceiverSet {
 
             if let Some(index) = remove_index {
                 self.readers.swap_remove(index);
-            }
-
-            // if we didn't dequeue at least one complete message -- we need to loop through GetQueuedCS again;
-            // otherwise we're done.
-            if !selection_results.is_empty() {
-                break;
             }
         }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1355,7 +1355,7 @@ impl OsIpcReceiverSet {
                     }
                 }
 
-                // We may have already been closed, or the read resulted in us being closed.
+                // Instead of new data, we might have received a broken pipe notification.
                 // If so, add that to the result and remove the reader from our list.
                 if reader.closed {
                     win32_trace!("[# {:?}] receiver {:?} ({}) -- now closed!", *self.iocp, *reader.handle, reader.set_id.unwrap());

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -633,11 +633,11 @@ impl MessageReader {
                      oob.big_data_receiver_handle);
 
                 unsafe {
-                    for handle in oob.channel_handles.iter() {
-                        channels.push(OsOpaqueIpcChannel::new(*handle as HANDLE));
+                    for handle in oob.channel_handles {
+                        channels.push(OsOpaqueIpcChannel::new(handle as HANDLE));
                     }
 
-                    for sh in oob.shmem_handles.iter() {
+                    for sh in oob.shmem_handles {
                         shmems.push(OsIpcSharedMemory::from_handle(sh.0 as HANDLE, sh.1 as usize).unwrap());
                     }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -559,6 +559,57 @@ impl MessageReader {
         self.read_buf.set_len(new_size);
     }
 
+    /// Attempt to conclude an already issued async read operation.
+    ///
+    /// If successful, the result will be ready for picking up by `get_message()`.
+    ///
+    /// (`get_message()` might still yield nothing though,
+    /// in case only part of the message was received in this read,
+    /// and further read operations are necessary to get the rest.)
+    ///
+    /// In non-blocking mode, this may return with `WinError:NoData`,
+    /// while the async operation remains in flight.
+    ///
+    /// Note: Upon successful return,
+    /// the internal `ov` and `read_buf` fields
+    /// won't be aliased by the kernel anymore.
+    /// When getting `NoData` however,
+    /// access to these fields remains invalid,
+    /// i.e. we are still in unsafe mode in that case!
+    fn fetch_async_result(&mut self, blocking_mode: BlockingMode) -> Result<(), WinError> {
+        unsafe {
+            assert!(self.read_in_progress);
+
+            // Get the overlapped result, blocking if we need to.
+            let mut nbytes: u32 = 0;
+            let mut err = winapi::ERROR_SUCCESS;
+            let block = match blocking_mode {
+                BlockingMode::Blocking => winapi::TRUE,
+                BlockingMode::Nonblocking => winapi::FALSE,
+            };
+            let ok = kernel32::GetOverlappedResult(*self.handle,
+                                                   self.ov.deref_mut(),
+                                                   &mut nbytes,
+                                                   block);
+            if ok == winapi::FALSE {
+                err = GetLastError();
+                if blocking_mode == BlockingMode::Nonblocking && err == winapi::ERROR_IO_INCOMPLETE {
+                    // Async read hasn't completed yet.
+                    // Inform the caller, while keeping the read in flight.
+                    return Err(WinError::NoData);
+                }
+                // We pass err through to notify_completion so
+                // that it can handle other errors.
+            }
+
+            // Notify that the read completed, which will update the
+            // read pointers
+            self.notify_completion(err);
+        }
+
+        Ok(())
+    }
+
     fn get_message(&mut self) -> Result<Option<(Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>)>,
                                         WinError> {
         // Never touch the buffer while it's still mutably aliased by the kernel!
@@ -784,11 +835,6 @@ pub struct OsIpcReceiver {
 // While this seems to be true as far as I can tell,
 // it's a rather fragile condition, which should be managed much more tightly
 // (along with `OVERLAPPED` in general): at `MessageReader` level, at the very most.
-// The current implementation doesn't follow such a strict encapsulation however,
-// with `OsIpcReceiver` directly accessing `reader.ov` (in `receive_message()`),
-// outside the `MessageReader` implementation --
-// so for now, `OsIpcReceiver` needs to be considered responsible as a whole
-// for upholding the non-aliasing condition.
 unsafe impl Send for OsIpcReceiver { }
 
 impl PartialEq for OsIpcReceiver {
@@ -879,41 +925,22 @@ impl OsIpcReceiver {
                     return Err(WinError::ChannelClosed);
                 }
 
-                // Then, get the overlapped result, blocking if we need to.
-                let mut nbytes: u32 = 0;
-                let mut err = winapi::ERROR_SUCCESS;
-                let block = match blocking_mode {
-                    BlockingMode::Blocking => winapi::TRUE,
-                    BlockingMode::Nonblocking => winapi::FALSE,
-                };
-                let ok = kernel32::GetOverlappedResult(*reader.handle,
-                                                       reader.ov.deref_mut(),
-                                                       &mut nbytes,
-                                                       block);
-                if ok == winapi::FALSE {
-                    err = GetLastError();
-                    if blocking_mode == BlockingMode::Nonblocking && err == winapi::ERROR_IO_INCOMPLETE {
-                        // Nonblocking read, no message, read's in flight, we're
-                        // done.  An error is expected in this case.
-                        //
-                        // Note: This leaks unsafety outside the `unsafe` block,
-                        // since the method returns while an async read is still in progress;
-                        // meaning the kernel still holds a mutable alias
-                        // of the read buffer and `OVERLAPPED` structure
-                        // that the Rust type system doesn't know about --
-                        // nothing prevents code that isn't marked as `unsafe`
-                        // from performing invalid reads or writes to these fields!
-                        //
-                        // (See documentation of `ov`, `read_buf`, and `read_in_progress` fields.)
-                        return Err(WinError::NoData);
-                    }
-                    // We pass err through to notify_completion so
-                    // that it can handle other errors.
-                }
-
-                // Notify that the read completed, which will update the
-                // read pointers
-                reader.notify_completion(err);
+                // May return `WinError::NoData` in non-blocking mode.
+                //
+                // The async read remains in flight in that case;
+                // and another attempt at getting a result
+                // can be done the next time we are called.
+                //
+                // Note: This leaks unsafety outside the `unsafe` block,
+                // since the method returns while an async read is still in progress;
+                // meaning the kernel still holds a mutable alias
+                // of the read buffer and `OVERLAPPED` structure
+                // that the Rust type system doesn't know about --
+                // nothing prevents code that isn't marked as `unsafe`
+                // from performing invalid reads or writes to these fields!
+                //
+                // (See documentation of `ov`, `read_buf`, and `read_in_progress` fields.)
+                try!(reader.fetch_async_result(blocking_mode));
             }
 
             // If we're not blocking, pretend that we are blocking, since we got part of

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -559,9 +559,6 @@ impl MessageReader {
         self.read_buf.set_len(new_size);
     }
 
-    // This is split between get_message and get_message_inner, so that
-    // this function can handle removing bytes from the buffer, since
-    // get_message_inner borrows the buffer.
     fn get_message(&mut self) -> Result<Option<(Vec<u8>, Vec<OsOpaqueIpcChannel>, Vec<OsIpcSharedMemory>)>,
                                         WinError> {
         // Never touch the buffer while it's still mutably aliased by the kernel!

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -335,11 +335,11 @@ impl PartialEq for WinHandle {
         unsafe {
             // Calling LoadLibraryA every time seems to be ok since libraries are refcounted and multiple calls won't produce multiple instances.
             let module_handle = winapi::um::libloaderapi::LoadLibraryA(WINDOWS_APP_MODULE_NAME_CSTRING.as_ptr());
-            if module_handle == 0 as *mut _ {
+            if module_handle.is_null() {
                 panic!("Error loading library {}. {}", WINDOWS_APP_MODULE_NAME, WinError::error_string(GetLastError()));
             }
             let proc = winapi::um::libloaderapi::GetProcAddress(module_handle, COMPARE_OBJECT_HANDLES_FUNCTION_NAME_CSTRING.as_ptr());
-            if proc == 0 as *mut _ {
+            if proc.is_null() {
                 panic!("Error calling GetProcAddress to use {}. {}", COMPARE_OBJECT_HANDLES_FUNCTION_NAME, WinError::error_string(GetLastError()));
             }
             let compare_object_handles: unsafe extern "stdcall" fn(HANDLE, HANDLE) -> winapi::shared::minwindef::BOOL = std::mem::transmute(proc);

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -535,6 +535,7 @@ impl MessageReader {
         // (And it's safe again to access the `ov` and `read_buf` fields.)
         self.read_in_progress = false;
 
+        // Remote end closed the channel.
         if err == winapi::ERROR_BROKEN_PIPE {
             assert!(!self.closed, "we shouldn't get an async BROKEN_PIPE after we already got one");
             self.closed = true;
@@ -546,7 +547,6 @@ impl MessageReader {
 
         assert!(offset == 0);
 
-        // if the remote end closed...
         if err != winapi::ERROR_SUCCESS {
             // This should never happen
             panic!("[$ {:?}] *** notify_completion: unhandled error reported! {}", self.handle, err);

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -715,7 +715,7 @@ impl MessageReader {
     /// and the transfer doesn't have our typical message framing.
     ///
     /// It's only valid to call this as the one and only call after creating a MessageReader.
-    fn read_raw_sized(&mut self, size: usize) -> Result<Vec<u8>,WinError> {
+    fn read_raw_sized(mut self, size: usize) -> Result<Vec<u8>,WinError> {
         assert!(self.read_buf.len() == 0);
 
         // We use with_capacity() to allocate an uninitialized buffer,
@@ -1017,7 +1017,7 @@ impl OsIpcReceiver {
     ///
     /// This is used for receiving data from the out-of-band big data buffer.
     fn recv_raw(self, size: usize) -> Result<Vec<u8>, WinError> {
-        self.reader.borrow_mut().read_raw_sized(size)
+        self.reader.into_inner().read_raw_sized(size)
     }
 }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -637,8 +637,8 @@ impl MessageReader {
                         channels.push(OsOpaqueIpcChannel::new(handle as HANDLE));
                     }
 
-                    for sh in oob.shmem_handles {
-                        shmems.push(OsIpcSharedMemory::from_handle(sh.0 as HANDLE, sh.1 as usize).unwrap());
+                    for (handle, size) in oob.shmem_handles {
+                        shmems.push(OsIpcSharedMemory::from_handle(handle as HANDLE, size as usize).unwrap());
                     }
 
                     if oob.big_data_receiver_handle.is_some() {

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -684,9 +684,10 @@ impl MessageReader {
         unsafe {
             assert!(self.set_id.is_none());
 
+            let completion_key = self.handle.as_raw() as winapi::ULONG_PTR;
             let ret = kernel32::CreateIoCompletionPort(self.handle.as_raw(),
                                                        iocp.as_raw(),
-                                                       self.handle.as_raw() as winapi::ULONG_PTR,
+                                                       completion_key,
                                                        0);
             if ret.is_null() {
                 return Err(WinError::last("CreateIoCompletionPort"));

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -870,11 +870,8 @@ impl OsIpcReceiver {
         loop {
             // First, try to fetch a message, in case we have one pending
             // in the reader's receive buffer
-            match try!(reader.get_message()) {
-                Some((data, channels, shmems)) =>
-                    return Ok((data, channels, shmems)),
-                None =>
-                    {},
+            if let Some((data, channels, shmems)) = try!(reader.get_message()) {
+                return Ok((data, channels, shmems));
             }
 
             // If the pipe was already closed, we're done -- we've

--- a/src/test.rs
+++ b/src/test.rs
@@ -38,7 +38,7 @@ use std::process::{self, Command, Stdio};
     target_os = "android",
     target_os = "ios"
 )))]
-
+use std::ptr;
 use std::sync::Arc;
 use std::thread;
 
@@ -47,12 +47,14 @@ use std::thread;
     target_os = "android",
     target_os = "ios"
 )))]
+use crate::ipc::IpcOneShotServer;
 
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "android",
     target_os = "ios"
 )))]
+use std::io::Error;
 
 #[cfg(not(any(
     feature = "force-inprocess",

--- a/src/test.rs
+++ b/src/test.rs
@@ -444,8 +444,6 @@ fn shared_memory() {
 }
 
 #[test]
-// The Windows implementation can't handle this case due to system API limitations.
-#[cfg_attr(all(target_os = "windows", not(feature = "force-inprocess")), ignore)]
 fn shared_memory_object_equality() {
     let person = ("Patrick Walton".to_owned(), 29);
     let person_and_shared_memory = (person, IpcSharedMemory::from_byte(0xba, 1024 * 1024));

--- a/src/test.rs
+++ b/src/test.rs
@@ -444,6 +444,7 @@ fn shared_memory() {
 }
 
 #[test]
+#[cfg(any(not(target_os = "windows"), all(target_os = "windows", feature = "windows-shared-memory-equality")))]
 fn shared_memory_object_equality() {
     let person = ("Patrick Walton".to_owned(), 29);
     let person_and_shared_memory = (person, IpcSharedMemory::from_byte(0xba, 1024 * 1024));

--- a/src/test.rs
+++ b/src/test.rs
@@ -38,7 +38,7 @@ use std::process::{self, Command, Stdio};
     target_os = "android",
     target_os = "ios"
 )))]
-use std::ptr;
+
 use std::sync::Arc;
 use std::thread;
 
@@ -47,14 +47,12 @@ use std::thread;
     target_os = "android",
     target_os = "ios"
 )))]
-use crate::ipc::IpcOneShotServer;
 
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "android",
     target_os = "ios"
 )))]
-use std::io::Error;
 
 #[cfg(not(any(
     feature = "force-inprocess",


### PR DESCRIPTION
This is a rebase of #233 with some updates, namely
 * fixed unresolved dependencies
 * impls of error conversions
 * remaining work explained in https://github.com/servo/ipc-channel/pull/233#issuecomment-534597659

Existing tests passed on my Windows 10 PC with toolchain `nightly-x86_64-pc-windows-msvc` running `cargo test --features="windows-shared-memory-equality,unstable"`, `cargo test --features="windows-shared-memory-equality"` and `cargo test --features="force-inprocess,windows-shared-memory-equality"` so far.

Happened to need this, hope it helps...