### PR TITLE
Rust 2018 syntax and misc updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ windows-shared-memory-equality = []
 
 [dependencies]
 bincode = "1"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 fnv = "1.0.3"
 futures-preview = { version = "0.3.0-alpha.17", optional = true }
 futures-test-preview = { version = "0.3.0-alpha.17", optional = true }
 lazy_static = "1"
 libc = "0.2.12"
-rand = "0.7"
+rand = "0.8"
 serde = { version = "1.0", features = ["rc"] }
 tempfile = "3"
 uuid = { version = "0.8", features = ["v4"] }
@@ -33,7 +33,7 @@ mio = "0.6.11"
 sc = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
-crossbeam-utils = "0.7"
+crossbeam-utils = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = {version = "0.3.7", features = ["minwindef", "ioapiset", "memoryapi", "namedpipeapi", "handleapi", "fileapi", "impl-default"]}

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
-
-extern crate ipc_channel;
 extern crate test;
+
 
 /// Allows doing multiple inner iterations per bench.iter() run.
 ///
@@ -14,12 +13,8 @@ extern crate test;
 const ITERATIONS: usize = 1;
 
 mod platform {
-    extern crate crossbeam_utils;
-
     use crate::ITERATIONS;
     use ipc_channel::platform;
-
-    use crate::test;
     use std::sync::{mpsc, Mutex};
 
     #[bench]
@@ -182,8 +177,6 @@ mod ipc {
     use crate::ITERATIONS;
     use ipc_channel::ipc;
 
-    use crate::test;
-
     #[bench]
     fn transfer_empty(b: &mut test::Bencher) {
         let (tx, rx) = ipc::channel().unwrap();
@@ -268,9 +261,7 @@ mod ipc {
     mod receiver_set {
         use crate::ITERATIONS;
         use ipc_channel::ipc::{self, IpcReceiverSet};
-
-        use crate::test;
-
+        
         // Benchmark selecting over a set of `n` receivers,
         // with `to_send` of them actually having pending data.
         fn bench_send_on_m_of_n(b: &mut test::Bencher, to_send: usize, n: usize) {

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -27,6 +27,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Mutex;
 use std::thread;
+use lazy_static::lazy_static;
 
 /// A stream built from an IPC channel.
 pub struct IpcStream<T>(UnboundedReceiver<OpaqueIpcMessage>, PhantomData<T>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,16 +36,6 @@
 //! [OsIpcSharedMemory]: platform/struct.OsIpcSharedMemory.html
 //! [memfd_create]: http://man7.org/linux/man-pages/man2/memfd_create.2.html
 
-use bincode;
-
-
-#[macro_use]
-extern crate lazy_static;
-
-
-
-
-
 
 #[cfg(any(
     feature = "force-inprocess",
@@ -53,27 +43,25 @@ extern crate lazy_static;
     target_os = "android",
     target_os = "ios"
 ))]
-extern crate uuid;
+use uuid;
 #[cfg(all(
     feature = "memfd",
     not(feature = "force-inprocess"),
     target_os = "linux"
 ))]
-#[macro_use]
-extern crate sc;
+
 
 #[cfg(feature = "async")]
-extern crate futures;
+use futures;
 
 #[cfg(all(feature = "async", test))]
-extern crate futures_test;
+use futures_test;
 
 #[cfg(feature = "async")]
 pub mod asynch;
 
 #[cfg(all(not(feature = "force-inprocess"), target_os = "windows"))]
-extern crate winapi;
-
+use winapi;
 
 pub mod ipc;
 pub mod platform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,26 +36,19 @@
 //! [OsIpcSharedMemory]: platform/struct.OsIpcSharedMemory.html
 //! [memfd_create]: http://man7.org/linux/man-pages/man2/memfd_create.2.html
 
-
 #[cfg(any(
     feature = "force-inprocess",
     target_os = "windows",
     target_os = "android",
     target_os = "ios"
 ))]
-use uuid;
 #[cfg(all(
     feature = "memfd",
     not(feature = "force-inprocess"),
     target_os = "linux"
 ))]
-
-
 #[cfg(feature = "async")]
 use futures;
-
-#[cfg(all(feature = "async", test))]
-use futures_test;
 
 #[cfg(feature = "async")]
 pub mod asynch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,25 +36,17 @@
 //! [OsIpcSharedMemory]: platform/struct.OsIpcSharedMemory.html
 //! [memfd_create]: http://man7.org/linux/man-pages/man2/memfd_create.2.html
 
-extern crate bincode;
-extern crate crossbeam_channel;
+use bincode;
+
 
 #[macro_use]
 extern crate lazy_static;
-#[cfg(all(
-    not(feature = "force-inprocess"),
-    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
-))]
-extern crate fnv;
-extern crate libc;
-#[cfg(all(
-    not(feature = "force-inprocess"),
-    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
-))]
-extern crate mio;
-extern crate rand;
-extern crate serde;
-extern crate tempfile;
+
+
+
+
+
+
 #[cfg(any(
     feature = "force-inprocess",
     target_os = "windows",

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -21,6 +21,7 @@ use std::cmp::{PartialEq};
 use std::ops::{Deref, RangeFrom};
 use std::usize;
 use uuid::Uuid;
+use lazy_static::lazy_static;
 
 #[derive(Clone)]
 struct ServerRecord {

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -224,6 +224,7 @@ fn with_n_fds(n: usize, size: usize) {
 mod fragment_tests {
     use crate::platform;
     use super::with_n_fds;
+    use lazy_static::lazy_static;
 
     lazy_static! {
         static ref FRAGMENT_SIZE: usize = {

--- a/src/platform/windows/aliased_cell.rs
+++ b/src/platform/windows/aliased_cell.rs
@@ -20,7 +20,7 @@ impl Drop for DropBomb {
         if thread::panicking() {
             eprintln!("{}", message);
         } else {
-            panic!(message);
+            panic!("{}", message);
         }
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -31,6 +31,7 @@ use winapi::um::winnt::{HANDLE};
 use winapi::um::handleapi::{INVALID_HANDLE_VALUE};
 use winapi::shared::minwindef::{LPVOID};
 use winapi;
+use lazy_static::lazy_static;
 
 mod aliased_cell;
 use self::aliased_cell::AliasedCell;

--- a/src/router.rs
+++ b/src/router.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::thread;
+use lazy_static::lazy_static;
 
 use crate::ipc::OpaqueIpcReceiver;
 use crate::ipc::{


### PR DESCRIPTION
In this PR i wanted to take advantage of the idioms of Rust 2018, update the dependecies to the latest public version and remove deprecated code.

* `crossbeam-channel` updated from `0.4` to `0.5`.
* `rand` from `0.7` to `0.8`.
* `crossbeam-utils` from `0.7` to `0.8`.
* Removed the `extern crate` and `#[macro_use]` syntax, replaced by `use` where it's needed.
* Replaced `std::mem::replace` with `std::mem::take`.
* **[In `unsafe fn`]** Replaced the decprecated `mem::uninitialized` with `mem::MaybeUninit::uninit()`.
* **[In `unsafe` code block]** Replaced `ptr.offset(offset as isize)` with `ptr.add(offset)`. [relative clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_with_cast)

Tested with:
* `cargo +nightly build --release --all-features --all-targets`
* `cargo +nightly test --all-features --all-targets`
* `cargo +nightly bench --all-features --all-targets`

I **didn't** formatted the code with `cargo fmt` because it would have brought too much changes, if necessary I'm ready to send a new patch.