### PR TITLE
Update futures to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ windows-shared-memory-equality = []
 bincode = "1"
 crossbeam-channel = "0.4"
 fnv = "1.0.3"
-futures-preview = { version = "0.3.0-alpha.17", optional = true }
-futures-test-preview = { version = "0.3.0-alpha.17", optional = true }
+futures = "0.3"
+futures-test = "0.3"
 lazy_static = "1"
 libc = "0.2.12"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ windows-shared-memory-equality = []
 bincode = "1"
 crossbeam-channel = "0.4"
 fnv = "1.0.3"
-futures = "0.3"
-futures-test = "0.3"
+futures = { version = "0.3", optional = true }
+futures-test = { version = "0.3", optional = true }
 lazy_static = "1"
 libc = "0.2.12"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 force-inprocess = []
 memfd = ["sc"]
 unstable = []
-async = ["futures-preview", "futures-test-preview"]
+async = ["futures", "futures-test"]
 win32-trace = []
 windows-shared-memory-equality = []
 


### PR DESCRIPTION
Using the `asynch` package with newer futures is failing to compile when trying to use the `futures.stream::StreamExt` module.

```
 | pub struct IpcStream<T>(UnboundedReceiver<OpaqueIpcMessage>, PhantomData<T>);
   | -----------------------------------------------------------------------------
   | |
   | doesn't satisfy `IpcStream<StorageThreadMsg>: futures::StreamExt`
   | doesn't satisfy `IpcStream<StorageThreadMsg>: futures::Stream`
   |
   = note: the following trait bounds were not satisfied:
           `IpcStream<StorageThreadMsg>: futures::Stream`
           which is required by `IpcStream<StorageThreadMsg>: futures::StreamExt`
   = help: items from traits can only be used if the trait is in scope
```