### PR TITLE
FusedStream for IpcStream

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -112,3 +112,12 @@ where
         }
     }
 }
+
+impl<T> FusedStream for IpcStream<T> 
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    fn is_terminated(&self) -> bool {
+        self.0.is_terminated()
+    }
+}


### PR DESCRIPTION
Implements `FusedStream` trait for `IpcStream`, so allow the usage of the [`select!` macro](https://docs.rs/futures/0.3.18/futures/stream/trait.FusedStream.html). 