### PR TITLE
chore: use `panic!("{}", ...)` in prep. for Rust 2021 edition

### DIFF
--- a/src/platform/windows/aliased_cell.rs
+++ b/src/platform/windows/aliased_cell.rs
@@ -20,7 +20,7 @@ impl Drop for DropBomb {
         if thread::panicking() {
             eprintln!("{}", message);
         } else {
-            panic!(message);
+            panic!("{}", message);
         }
     }
 }


### PR DESCRIPTION
This PR paves the way for migration to Rust 2021 (if the team is willing). Even if Rust 2021 is not interesting for `ipc-channel`'s roadmap, it's one less lint for `rustc` to report!