### PR TITLE
Upgrade dependencies, and fix warn.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ windows-shared-memory-equality = []
 
 [dependencies]
 bincode = "1"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 fnv = "1.0.3"
 futures = { version = "0.3", optional = true }
 futures-test = { version = "0.3", optional = true }
@@ -26,14 +26,14 @@ libc = "0.2.12"
 rand = "0.7"
 serde = { version = "1.0", features = ["rc"] }
 tempfile = "3"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
 mio = "0.6.11"
 sc = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
-crossbeam-utils = "0.7"
+crossbeam-utils = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = {version = "0.3.7", features = ["minwindef", "ioapiset", "memoryapi", "namedpipeapi", "handleapi", "fileapi", "impl-default", "synchapi"]}


### PR DESCRIPTION
1. Upgrade `crossbeam-utils` to fix Race Condition vulnerability: <https://github.com/jmjoy/php-skywalking-agent/security/dependabot/1>
2. Upgrade uuid to stable version.
3. Fix Cargo check warn.