### PR TITLE
Port windows implementation from winapi to windows-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/ipc-channel"
-edition = "2018"
+edition = "2021"
 
 [features]
 force-inprocess = []
@@ -13,7 +13,7 @@ memfd = ["sc"]
 unstable = []
 async = ["futures", "futures-test"]
 win32-trace = []
-windows-shared-memory-equality = []
+windows-shared-memory-equality = ["windows/Win32_System_LibraryLoader"]
 
 [dependencies]
 bincode = "1"
@@ -35,16 +35,14 @@ sc = { version = "0.2.2", optional = true }
 [dev-dependencies]
 crossbeam-utils = "0.8"
 
-[target.'cfg(target_os = "windows")'.dependencies.winapi]
-version = "0.3.7"
-features = [
-  "minwindef",
-  "ioapiset",
-  "memoryapi",
-  "namedpipeapi",
-  "handleapi",
-  "fileapi",
-  "impl-default",
-  "synchapi",
-  "errhandlingapi"
-]
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.40.0", features = [
+    "Win32_Foundation",
+    "Win32_System_WindowsProgramming",
+    "Win32_System_Threading",
+    "Win32_System_Pipes",
+    "Win32_System_Memory",
+    "Win32_System_IO",
+    "Win32_Storage_FileSystem",
+    "Win32_Security",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ sc = { version = "0.2.2", optional = true }
 [dev-dependencies]
 crossbeam-utils = "0.8"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.40.0", features = [
+[target.'cfg(target_os = "windows")'.dependencies.windows]
+version = "0.48.0"
+features = [
     "Win32_Foundation",
     "Win32_System_WindowsProgramming",
     "Win32_System_Threading",
@@ -45,4 +46,4 @@ windows = { version = "0.40.0", features = [
     "Win32_System_IO",
     "Win32_Storage_FileSystem",
     "Win32_Security",
-] }
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1"
 libc = "0.2.12"
 rand = "0.7"
 serde = { version = "1.0", features = ["rc"] }
-tempfile = "3"
+tempfile = "3.4"
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ extern crate futures_test;
 pub mod asynch;
 
 #[cfg(all(not(feature = "force-inprocess"), target_os = "windows"))]
-extern crate winapi;
+extern crate windows;
 
 
 pub mod ipc;

--- a/src/test.rs
+++ b/src/test.rs
@@ -388,7 +388,7 @@ fn router_drops_callbacks_on_sender_shutdown() {
     let dropper = Dropper { sender: drop_tx };
 
     let router = RouterProxy::new();
-    router.add_route(rx0.to_opaque(), Box::new(move |_| { let _ = dropper; }));
+    router.add_route(rx0.to_opaque(), Box::new(move |_| { let _ = &dropper; }));
     drop(tx0);
     assert_eq!(drop_rx.recv(), Ok(42));
 }
@@ -410,7 +410,7 @@ fn router_drops_callbacks_on_cloned_sender_shutdown() {
     let dropper = Dropper { sender: drop_tx };
 
     let router = RouterProxy::new();
-    router.add_route(rx0.to_opaque(), Box::new(move |_| { let _ = dropper; }));
+    router.add_route(rx0.to_opaque(), Box::new(move |_| { let _ = &dropper; }));
     let txs = vec![tx0.clone(), tx0.clone(), tx0.clone()];
     drop(txs);
     drop(tx0);

--- a/src/test.rs
+++ b/src/test.rs
@@ -30,13 +30,15 @@ use std::iter;
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "android",
-    target_os = "ios"
+    target_os = "ios",
+    all(target_os = "windows", not(feature = "windows-shared-memory-equality"))
 )))]
 use std::process::{self, Command, Stdio};
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "android",
-    target_os = "ios"
+    target_os = "ios",
+    target_os = "windows",
 )))]
 use std::ptr;
 use std::sync::Arc;
@@ -45,14 +47,16 @@ use std::thread;
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "android",
-    target_os = "ios"
+    target_os = "ios",
+    target_os = "windows"
 )))]
 use crate::ipc::IpcOneShotServer;
 
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "android",
-    target_os = "ios"
+    target_os = "ios",
+    target_os = "windows",
 )))]
 use std::io::Error;
 use std::time::{Duration, Instant};
@@ -114,7 +118,7 @@ pub fn get_channel_name_arg(which: &str) -> Option<String> {
 
 // Helper to get a channel_name argument passed in; used for the
 // cross-process spawn server tests.
-#[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios")))]
+#[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios", all(target_os = "windows", not(feature = "windows-shared-memory-equality")))))]
 pub fn spawn_server(test_name: &str, server_args: &[(&str, &str)]) -> process::Child {
     Command::new(env::current_exe().unwrap())
         .arg(test_name)


### PR DESCRIPTION
`winapi` hasn't been updated since November of 2021, and the ecosystem seems to be making a general shift towards the officially supported `windows` crate instead. This PR moves `ipc-channel` to `windows`.