### PR TITLE
Upgrade to `mio` 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tempfile = "3.4"
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
-mio = "0.6.11"
+mio = { version = "0.8", features = ["os-ext"] }
 sc = { version = "0.2.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This change upgrades `mio` for non-MacOS / non-Android unix platforms.
`mio` is used an abstraction layer over the various methods of doing
`epoll`, etc on Unix platforms.

There are a few notable changes this upgrade deals with:

- `mio` no longer supports level-triggered events. What this means is
  that instead of always delivering readable events for file
  descriptors when there is data left to read, an event is only
  delivered the first time new data becomes available. The consumer is
  expected to try to read from descriptor until it would block. This
  means we have to put a loop around calls to recv for each file
  descriptor. Note that this might change the order that messages
  arrive, since before each polling operation would only give one
  message per fd. Now all available messages are delivered per call to
  poll.
- The `mio` API has changed a bit. Now there's a poll registry and also
  `Ready` has been replaced by `Interest`.
