### PR TITLE
Remove usage of `extern crate`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,4 @@
 #![feature(test)]
-
-extern crate ipc_channel;
 extern crate test;
 
 /// Allows doing multiple inner iterations per bench.iter() run.
@@ -14,12 +12,8 @@ extern crate test;
 const ITERATIONS: usize = 1;
 
 mod platform {
-    extern crate crossbeam_utils;
-
     use crate::ITERATIONS;
     use ipc_channel::platform;
-
-    use crate::test;
     use std::sync::{mpsc, Mutex};
 
     #[bench]
@@ -182,8 +176,6 @@ mod ipc {
     use crate::ITERATIONS;
     use ipc_channel::ipc;
 
-    use crate::test;
-
     #[bench]
     fn transfer_empty(b: &mut test::Bencher) {
         let (tx, rx) = ipc::channel().unwrap();
@@ -268,8 +260,6 @@ mod ipc {
     mod receiver_set {
         use crate::ITERATIONS;
         use ipc_channel::ipc::{self, IpcReceiverSet};
-
-        use crate::test;
 
         // Benchmark selecting over a set of `n` receivers,
         // with `to_send` of them actually having pending data.

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -20,6 +20,7 @@ use futures::stream::FusedStream;
 use futures::task::Context;
 use futures::task::Poll;
 use futures::Stream;
+use lazy_static::lazy_static;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,45 +36,19 @@
 //! [OsIpcSharedMemory]: platform/struct.OsIpcSharedMemory.html
 //! [memfd_create]: http://man7.org/linux/man-pages/man2/memfd_create.2.html
 
-extern crate bincode;
-extern crate crossbeam_channel;
-
-#[macro_use]
-extern crate lazy_static;
-#[cfg(all(
-    not(feature = "force-inprocess"),
-    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
-))]
-extern crate fnv;
-extern crate libc;
-#[cfg(all(
-    not(feature = "force-inprocess"),
-    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
-))]
-extern crate mio;
-extern crate rand;
-extern crate serde;
-extern crate tempfile;
 #[cfg(any(
     feature = "force-inprocess",
     target_os = "windows",
     target_os = "android",
     target_os = "ios"
 ))]
-extern crate uuid;
 #[cfg(all(
     feature = "memfd",
     not(feature = "force-inprocess"),
     target_os = "linux"
 ))]
-#[macro_use]
-extern crate sc;
-
 #[cfg(feature = "async")]
-extern crate futures;
-
-#[cfg(all(feature = "async", test))]
-extern crate futures_test;
+use futures;
 
 #[cfg(feature = "async")]
 pub mod asynch;

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -10,6 +10,7 @@
 use crate::ipc;
 use bincode;
 use crossbeam_channel::{self, Receiver, RecvTimeoutError, Select, Sender, TryRecvError};
+use lazy_static::lazy_static;
 use std::cell::{Ref, RefCell};
 use std::cmp::PartialEq;
 use std::collections::hash_map::HashMap;

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -15,6 +15,7 @@ use self::mach_sys::{mach_port_right_t, mach_port_t, mach_task_self_, vm_inherit
 use crate::ipc;
 
 use bincode;
+use lazy_static::lazy_static;
 use libc::{self, c_char, c_uint, c_void, size_t};
 use rand::{self, Rng};
 use std::cell::Cell;

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -305,6 +305,7 @@ fn with_n_fds(n: usize, size: usize) {
 mod fragment_tests {
     use super::with_n_fds;
     use crate::platform;
+    use lazy_static::lazy_static;
 
     lazy_static! {
         static ref FRAGMENT_SIZE: usize = { platform::OsIpcSender::get_max_fragment_size() };

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -10,6 +10,7 @@
 use crate::ipc;
 use bincode;
 use fnv::FnvHasher;
+use lazy_static::lazy_static;
 use libc::{self, MAP_FAILED, MAP_SHARED, PROT_READ, PROT_WRITE, SOCK_SEQPACKET, SOL_SOCKET};
 use libc::{c_char, c_int, c_void, getsockopt, SO_LINGER, S_IFMT, S_IFSOCK};
 use libc::{iovec, mode_t, msghdr, off_t, recvmsg, sendmsg};
@@ -17,6 +18,8 @@ use libc::{sa_family_t, setsockopt, size_t, sockaddr, sockaddr_un, socketpair, s
 use libc::{EAGAIN, EWOULDBLOCK};
 use mio::unix::SourceFd;
 use mio::{Events, Interest, Poll, Token};
+#[cfg(all(feature = "memfd", target_os = "linux"))]
+use sc::syscall;
 use std::cell::Cell;
 use std::cmp;
 use std::collections::HashMap;

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -9,6 +9,7 @@
 
 use crate::ipc;
 use bincode;
+use lazy_static::lazy_static;
 use serde;
 
 use std::{

--- a/src/router.rs
+++ b/src/router.rs
@@ -12,6 +12,7 @@
 //! `IpcReceiver<T>`s. The router will then either call the appropriate callback or route the
 //! message to a crossbeam `Sender<T>` or `Receiver<T>`. You should use the global `ROUTER` to
 //! access the `RouterProxy` methods (via `ROUTER`'s `Deref` for `RouterProxy`.
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::thread;


### PR DESCRIPTION
This is no longer necessary in recent versions of Rust.

This is a modified version of #280.
