### PR TITLE
Remove usage of unstable features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ["unstable", "unstable force-inprocess", "unstable memfd"]
+        features: ["", "force-inprocess", "memfd"]
     steps:
       - uses: actions/checkout@v3
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        features: ["unstable", "unstable force-inprocess"]
+        features: ["", "force-inprocess"]
 
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        features: ["unstable", "unstable force-inprocess", "unstable windows-shared-memory-equality"]
+        features: ["", "--features force-inprocess", "--features windows-shared-memory-equality"]
         target: ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
 
     steps:
@@ -75,10 +75,10 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cargo build
-        run: cargo build --features "${{ matrix.features }}" --target ${{ matrix.target }}
+        run: cargo build ${{ matrix.features }} --target ${{ matrix.target }}
 
       - name: Cargo test
-        run: cargo test --features "${{ matrix.features }}" --target ${{ matrix.target }}
+        run: cargo test ${{ matrix.features }} --target ${{ matrix.target }}
         env:
           RUST_BACKTRACE: 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 [features]
 force-inprocess = []
 memfd = ["sc"]
-unstable = []
 async = ["futures", "futures-test"]
 win32-trace = []
 windows-shared-memory-equality = ["windows/Win32_System_LibraryLoader"]
@@ -34,6 +33,7 @@ sc = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 crossbeam-utils = "0.8"
+static_assertions = "1.1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.48.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(all(feature = "unstable", test), feature(specialization))]
-
 //! An implementation of the Rust channel API over process boundaries. Under the
 //! hood, this API uses Mach ports on Mac and file descriptor passing over Unix
 //! sockets on Linux. The serde library is used to serialize values for transport

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -1232,27 +1232,13 @@ fn try_recv_large_delayed() {
     }
 }
 
-#[cfg(feature = "unstable")]
 mod sync_test {
     use crate::platform;
-
-    trait SyncTest {
-        fn test_not_sync();
-    }
-
-    impl<T> SyncTest for T {
-        default fn test_not_sync() {}
-    }
-
-    impl<T: Sync> SyncTest for T {
-        fn test_not_sync() {
-            panic!("`OsIpcSender` should not be `Sync`");
-        }
-    }
+    use static_assertions::assert_not_impl_any;
 
     #[test]
     fn receiver_not_sync() {
-        platform::OsIpcSender::test_not_sync();
+        assert_not_impl_any!(platform::OsIpcSender : Sync);
     }
 }
 


### PR DESCRIPTION
Use `static_assertions::assert_not_impl_any` to assert that OsIpcSender
doesn't implement Sync instead of relying on unstable rustc features.
This also makes it clearer what this code does.
