### PR TITLE
Release version 0.18.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.18.1"
+version = "0.18.2"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I previously tried to upgrade the version, but since I was using an old
checkout my change was simply eliminated from the commit during merge.
This PR actually cuts a new version (0.18.2).
