### PR TITLE
ci: Make it so that the workflow fails is any job fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,16 +85,17 @@ jobs:
   build_result:
     name: Result
     runs-on: ubuntu-latest
+    if: always()
     needs:
       - "linux-ci"
       - "mac-ci"
       - "windows-ci"
 
     steps:
-      - name: Mark the job as successful
+      - name: Success
         run: exit 0
-        if: success()
-      - name: Mark the job as unsuccessful
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      - name: Failure
         run: exit 1
-        if: "!success()"
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
 


### PR DESCRIPTION
This is the same setup we have in other Servo repositories.

Fixes #348.