### PR TITLE
ci: Add workflows for automated version publish

### DIFF
--- a/.github/workflows/prepare-new-release.yml
+++ b/.github/workflows/prepare-new-release.yml
@@ -1,0 +1,26 @@
+name: Prepare new release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  new-release:
+    name: Prepare new release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,29 @@
+name: Publish release
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
There is `Prepare new release` workflow which needs to be manually dispatched (only servo org members) to create new release PR: https://github.com/sagudev/ipc-channel/pull/1, then when release PR is merged (needs to be manually reviewed and merged, by only those who have access to merge button) `Publish release` publishes release to crates.io and creates GitHub release.


Based on https://release-plz.ieni.dev/docs/github/quickstart.

Needs for someone to follow instructions on https://release-plz.ieni.dev/docs/github/quickstart#1-change-github-actions-permissions for secrets and workflow permissions.

We will probably want to add @servo-bot to https://github.com/orgs/servo/teams/cargo-publish and use it's token for this.