### PR TITLE
Use c_int type for SO_SNDBUF (#355)

### DIFF
--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -213,8 +213,8 @@ impl OsIpcSender {
     /// Some of it is reserved by the kernel for bookkeeping.
     fn get_system_sendbuf_size(&self) -> Result<usize, UnixError> {
         unsafe {
-            let mut socket_sendbuf_size: usize = 0;
-            let mut socket_sendbuf_size_len = mem::size_of::<usize>() as socklen_t;
+            let mut socket_sendbuf_size: c_int = 0;
+            let mut socket_sendbuf_size_len = mem::size_of::<c_int>() as socklen_t;
             if getsockopt(
                 self.fd.0,
                 libc::SOL_SOCKET,
@@ -225,7 +225,7 @@ impl OsIpcSender {
             {
                 return Err(UnixError::last());
             }
-            Ok(socket_sendbuf_size)
+            Ok(socket_sendbuf_size.try_into().unwrap())
         }
     }
 


### PR DESCRIPTION
This is defined by POSIX as an 'int'.  Using a usize causes an invalid value to be read on 64-bit big endian platforms.

--

Passes tests on ppc64, x86_64, and i586 for me.