### PR TITLE
Expose `OpaqueIpcMessage` as `IpcMessage`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ name = "ipc_receiver_set"
 harness = false
 
 [features]
+default = []
 force-inprocess = []
 memfd = ["sc"]
 async = ["futures", "futures-test"]

--- a/src/router.rs
+++ b/src/router.rs
@@ -18,9 +18,7 @@ use std::sync::Mutex;
 use std::thread;
 
 use crate::ipc::OpaqueIpcReceiver;
-use crate::ipc::{
-    self, IpcReceiver, IpcReceiverSet, IpcSelectionResult, IpcSender, OpaqueIpcMessage,
-};
+use crate::ipc::{self, IpcMessage, IpcReceiver, IpcReceiverSet, IpcSelectionResult, IpcSender};
 use crossbeam_channel::{self, Receiver, Sender};
 use serde::{Deserialize, Serialize};
 
@@ -215,4 +213,4 @@ enum RouterMsg {
 }
 
 /// Function to call when a new event is received from the corresponding receiver.
-pub type RouterHandler = Box<dyn FnMut(OpaqueIpcMessage) + Send>;
+pub type RouterHandler = Box<dyn FnMut(IpcMessage) + Send>;


### PR DESCRIPTION
This makes the API a bit friendlier and future-proof. Instead of
returning a tuple from raw `recv()` return the `IpcMessage` struct that
is used internally in the crate. In addition, this is used to pass data
from the platform layer -- removing clippy warnings about complex data
types. One upside to this is that `Option<IpcSharedMemory>` is turned
into `IpcSharedMemory` in some places where having a `None` value
shouldn't be possible.

This simplification removes about 300 lines of code.
