### PR TITLE
Remove `windows-shared-memory-equality` feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
           - { target: i686-pc-windows-msvc, os: windows-latest }
         features: ["", "force-inprocess", "async"]
         include:
-          - features: "windows-shared-memory-equality"
+          - features: ""
             platform: { target: x86_64-pc-windows-msvc, os: windows-latest }
-          - features: "windows-shared-memory-equality"
+          - features: ""
             platform: { target: i686-pc-windows-msvc, os: windows-latest }
           - features: "memfd"
             platform: { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ force-inprocess = []
 memfd = ["sc"]
 async = ["futures", "futures-test"]
 win32-trace = []
-windows-shared-memory-equality = ["windows/Win32_System_LibraryLoader"]
 
 [dependencies]
 bincode = "1"

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -541,17 +541,9 @@ impl IpcReceiverSet {
 /// let shmem = IpcSharedMemory::from_bytes(&data);
 /// tx.send(shmem.clone()).unwrap();
 /// # let rx_shmem = rx.recv().unwrap();
-/// # #[cfg(any(not(target_os = "windows"), all(target_os = "windows", feature = "windows-shared-memory-equality")))]
 /// # assert_eq!(shmem, rx_shmem);
 /// ```
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    any(
-        not(target_os = "windows"),
-        all(target_os = "windows", feature = "windows-shared-memory-equality")
-    ),
-    derive(PartialEq)
-)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IpcSharedMemory {
     /// None represents no data (empty slice)
     os_shared_memory: Option<OsIpcSharedMemory>,

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -7,12 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Most of this file won't compile without `windows-shared-memory-equality` feature on Windows since `PartialEq` won't be implemented for `IpcSharedMemory`.
-#![cfg(any(
-    not(target_os = "windows"),
-    all(target_os = "windows", feature = "windows-shared-memory-equality")
-))]
-
 use crate::platform::OsIpcSharedMemory;
 use crate::platform::{self, OsIpcChannel, OsIpcReceiverSet};
 use std::collections::HashMap;

--- a/src/test.rs
+++ b/src/test.rs
@@ -17,12 +17,7 @@ use std::cell::RefCell;
 #[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios")))]
 use std::env;
 use std::iter;
-#[cfg(not(any(
-    feature = "force-inprocess",
-    target_os = "android",
-    target_os = "ios",
-    all(target_os = "windows", not(feature = "windows-shared-memory-equality"))
-)))]
+#[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios",)))]
 use std::process::{self, Command, Stdio};
 #[cfg(not(any(
     feature = "force-inprocess",
@@ -108,12 +103,7 @@ pub fn get_channel_name_arg(which: &str) -> Option<String> {
 
 // Helper to get a channel_name argument passed in; used for the
 // cross-process spawn server tests.
-#[cfg(not(any(
-    feature = "force-inprocess",
-    target_os = "android",
-    target_os = "ios",
-    all(target_os = "windows", not(feature = "windows-shared-memory-equality"))
-)))]
+#[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios",)))]
 pub fn spawn_server(test_name: &str, server_args: &[(&str, &str)]) -> process::Child {
     Command::new(env::current_exe().unwrap())
         .arg(test_name)
@@ -484,10 +474,6 @@ fn shared_memory_slice() {
 }
 
 #[test]
-#[cfg(any(
-    not(target_os = "windows"),
-    all(target_os = "windows", feature = "windows-shared-memory-equality")
-))]
 fn shared_memory_object_equality() {
     let person = ("Patrick Walton".to_owned(), 29);
     let person_and_shared_memory = (person, IpcSharedMemory::from_byte(0xba, 1024 * 1024));


### PR DESCRIPTION
This feature is useful because it allows compiling for versions of
Windows older than Windows 10. Windows 10 was released about a decade
ago, so I think it's fine to remove support for older versions of
Windows. For example Windows 7 is no longer supported as of January 2020
and it seems that less than 3% of users are using it.
