### PR TITLE
Implement typed routes for `ROUTER`

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -12,6 +12,7 @@
 //! `IpcReceiver<T>`s. The router will then either call the appropriate callback or route the
 //! message to a crossbeam `Sender<T>` or `Receiver<T>`. You should use the global `ROUTER` to
 //! access the `RouterProxy` methods (via `ROUTER`'s `Deref` for `RouterProxy`.
+
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -69,6 +70,23 @@ impl RouterProxy {
             .send(RouterMsg::AddRoute(receiver, callback))
             .unwrap();
         comm.wakeup_sender.send(()).unwrap();
+    }
+
+    /// Add a new `(receiver, callback)` pair to the router, and send a wakeup message
+    /// to the router.
+    ///
+    /// Unlike [add_route](Self::add_route) this method is strongly typed and guarantees
+    /// that the `receiver` and the `callback` use the same message type.
+    pub fn add_typed_route<T>(&self, receiver: IpcReceiver<T>, mut callback: TypedRouterHandler<T>)
+    where
+        T: Serialize + for<'de> Deserialize<'de> + 'static,
+    {
+        // Before passing the message on to the callback, turn it into the appropriate type
+        let modified_callback = move |msg: IpcMessage| {
+            let typed_message = msg.to::<T>().unwrap();
+            callback(typed_message)
+        };
+        self.add_route(receiver.to_opaque(), Box::new(modified_callback));
     }
 
     /// Send a shutdown message to the router containing a ACK sender,
@@ -214,3 +232,6 @@ enum RouterMsg {
 
 /// Function to call when a new event is received from the corresponding receiver.
 pub type RouterHandler = Box<dyn FnMut(IpcMessage) + Send>;
+
+/// Like [RouterHandler] but includes the type that will be passed to the callback
+pub type TypedRouterHandler<T> = Box<dyn FnMut(T) + Send>;

--- a/src/router.rs
+++ b/src/router.rs
@@ -121,9 +121,9 @@ impl RouterProxy {
     ) where
         T: for<'de> Deserialize<'de> + Serialize + Send + 'static,
     {
-        self.add_route(
-            ipc_receiver.to_opaque(),
-            Box::new(move |message| drop(crossbeam_sender.send(message.to::<T>().unwrap()))),
+        self.add_typed_route(
+            ipc_receiver,
+            Box::new(move |message| drop(crossbeam_sender.send(message))),
         )
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -284,6 +284,21 @@ fn router_simple_global() {
     let received_person = callback_fired_receiver.recv().unwrap();
     assert_eq!(received_person, person);
 
+    // Try the same, with a strongly typed route
+    let message: usize = 42;
+    let (tx, rx) = ipc::channel().unwrap();
+    tx.send(message.clone()).unwrap();
+
+    let (callback_fired_sender, callback_fired_receiver) = crossbeam_channel::unbounded::<usize>();
+    ROUTER.add_typed_route(
+        rx,
+        Box::new(move |message| {
+            callback_fired_sender.send(message).unwrap();
+        }),
+    );
+    let received_message = callback_fired_receiver.recv().unwrap();
+    assert_eq!(received_message, message);
+
     // Now shutdown the router.
     ROUTER.shutdown();
 


### PR DESCRIPTION
Implements `ROUTER::add_typed_route`, which (unlike `ROUTER::add_route`) knows about the type expected by the callback and makes it impossible to mismatch types between the receiver and the callback.

This method can be used pretty much exactly like `ROUTER::add_route`, I added a small test case that demonstrates this.

Closes #242