### PR TITLE
fix: make `IpcMessage` members non-public

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -665,9 +665,9 @@ impl IpcSelectionResult {
 /// [to]: #method.to
 #[derive(PartialEq)]
 pub struct IpcMessage {
-    pub data: Vec<u8>,
-    pub os_ipc_channels: Vec<OsOpaqueIpcChannel>,
-    pub os_ipc_shared_memory_regions: Vec<OsIpcSharedMemory>,
+    pub(crate) data: Vec<u8>,
+    pub(crate) os_ipc_channels: Vec<OsOpaqueIpcChannel>,
+    pub(crate) os_ipc_shared_memory_regions: Vec<OsIpcSharedMemory>,
 }
 
 impl IpcMessage {


### PR DESCRIPTION
The original `OpaqueIpcMessage` struct that was superseded by the new `IpcMessage` had only non-public members. Having the members of `IpcMessage` marked as `pub` also mean they become part of the API, which we don't expect to be useful. So this change just marks them as `pub(crate)`.