### PR TITLE
Mark `Router::add_route` as deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.18.3"
+version = "0.19.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/router.rs
+++ b/src/router.rs
@@ -83,7 +83,7 @@ impl RouterProxy {
     {
         // Before passing the message on to the callback, turn it into the appropriate type
         let modified_callback = move |msg: IpcMessage| {
-            let typed_message = msg.to::<T>().unwrap();
+            let typed_message = msg.to::<T>();
             callback(typed_message)
         };
         self.add_route(receiver.to_opaque(), Box::new(modified_callback));
@@ -123,7 +123,7 @@ impl RouterProxy {
     {
         self.add_typed_route(
             ipc_receiver,
-            Box::new(move |message| drop(crossbeam_sender.send(message))),
+            Box::new(move |message| drop(crossbeam_sender.send(message.unwrap()))),
         )
     }
 
@@ -234,4 +234,4 @@ enum RouterMsg {
 pub type RouterHandler = Box<dyn FnMut(IpcMessage) + Send>;
 
 /// Like [RouterHandler] but includes the type that will be passed to the callback
-pub type TypedRouterHandler<T> = Box<dyn FnMut(T) + Send>;
+pub type TypedRouterHandler<T> = Box<dyn FnMut(Result<T, bincode::Error>) + Send>;

--- a/src/router.rs
+++ b/src/router.rs
@@ -59,6 +59,10 @@ impl RouterProxy {
 
     /// Add a new (receiver, callback) pair to the router, and send a wakeup message
     /// to the router.
+    ///
+    /// Consider using [add_typed_route](Self::add_typed_route) instead, which prevents
+    /// mismatches between the receiver and callback types.
+    #[deprecated(since = "0.19", note = "please use 'add_typed_route' instead")]
     pub fn add_route(&self, receiver: OpaqueIpcReceiver, callback: RouterHandler) {
         let comm = self.comm.lock().unwrap();
 
@@ -86,6 +90,8 @@ impl RouterProxy {
             let typed_message = msg.to::<T>();
             callback(typed_message)
         };
+
+        #[allow(deprecated)]
         self.add_route(receiver.to_opaque(), Box::new(modified_callback));
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,7 +62,7 @@ impl RouterProxy {
     ///
     /// Consider using [add_typed_route](Self::add_typed_route) instead, which prevents
     /// mismatches between the receiver and callback types.
-    #[deprecated(since = "0.19", note = "please use 'add_typed_route' instead")]
+    #[deprecated(since = "0.19.0", note = "please use 'add_typed_route' instead")]
     pub fn add_route(&self, receiver: OpaqueIpcReceiver, callback: RouterHandler) {
         let comm = self.comm.lock().unwrap();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -293,7 +293,7 @@ fn router_simple_global() {
     ROUTER.add_typed_route(
         rx,
         Box::new(move |message| {
-            callback_fired_sender.send(message).unwrap();
+            callback_fired_sender.send(message.unwrap()).unwrap();
         }),
     );
     let received_message = callback_fired_receiver.recv().unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -275,6 +275,7 @@ fn router_simple_global() {
     tx.send(person.clone()).unwrap();
 
     let (callback_fired_sender, callback_fired_receiver) = crossbeam_channel::unbounded::<Person>();
+    #[allow(deprecated)]
     ROUTER.add_route(
         rx.to_opaque(),
         Box::new(move |person| {
@@ -308,10 +309,10 @@ fn router_simple_global() {
     tx.send(person.clone()).unwrap();
 
     let (callback_fired_sender, callback_fired_receiver) = crossbeam_channel::unbounded::<Person>();
-    ROUTER.add_route(
-        rx.to_opaque(),
+    ROUTER.add_typed_route(
+        rx,
         Box::new(move |person| {
-            callback_fired_sender.send(person.to().unwrap()).unwrap();
+            callback_fired_sender.send(person.unwrap()).unwrap();
         }),
     );
 
@@ -389,8 +390,8 @@ fn router_drops_callbacks_on_sender_shutdown() {
     let dropper = Dropper { sender: drop_tx };
 
     let router = RouterProxy::new();
-    router.add_route(
-        rx0.to_opaque(),
+    router.add_typed_route(
+        rx0,
         Box::new(move |_| {
             let _ = &dropper;
         }),
@@ -416,8 +417,8 @@ fn router_drops_callbacks_on_cloned_sender_shutdown() {
     let dropper = Dropper { sender: drop_tx };
 
     let router = RouterProxy::new();
-    router.add_route(
-        rx0.to_opaque(),
+    router.add_typed_route(
+        rx0,
         Box::new(move |_| {
             let _ = &dropper;
         }),
@@ -441,9 +442,9 @@ fn router_big_data() {
     let (callback_fired_sender, callback_fired_receiver) =
         crossbeam_channel::unbounded::<Vec<Person>>();
     let router = RouterProxy::new();
-    router.add_route(
-        rx.to_opaque(),
-        Box::new(move |people| callback_fired_sender.send(people.to().unwrap()).unwrap()),
+    router.add_typed_route(
+        rx,
+        Box::new(move |people| callback_fired_sender.send(people.unwrap()).unwrap()),
     );
     let received_people = callback_fired_receiver.recv().unwrap();
     assert_eq!(received_people, people);


### PR DESCRIPTION
* Marks `Router::add_route` as deprecated as discussed in https://github.com/servo/ipc-channel/pull/365#issuecomment-2413469573
* Creates a new minor release (that someone with the relevant permissions should push to crates.io). This is necessary for the `#[deprecated]` annotation
* Makes the callback of `Router::add_typed_route` receive a `Result<T, bincode::Error>` (https://github.com/servo/ipc-channel/pull/365#issuecomment-2413540813)
