### PR TITLE
Use more constants and functions from libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 [features]
 default = []
 force-inprocess = []
-memfd = ["sc"]
+memfd = []
 async = ["futures", "futures-test"]
 win32-trace = []
 
@@ -33,14 +33,13 @@ fnv = "1.0.3"
 futures = { version = "0.3", optional = true }
 futures-test = { version = "0.3", optional = true }
 lazy_static = "1"
-libc = "0.2.12"
+libc = "0.2.161"
 rand = "0.8"
 serde = { version = "1.0", features = ["rc"] }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
 mio = { version = "1.0", features = ["os-ext"] }
-sc = { version = "0.2.2", optional = true }
 tempfile = "3.4"
 
 [dev-dependencies]


### PR DESCRIPTION
I've been trying to port ipc-channel to illumos for use in a downstream project, and I found that this code was using a local copy of several functions and constants that are in libc. In particular:

* Some of the `CMSG_` functions were incorrect on illumos.
* `SCM_RIGHTS` was also not correct.

The correct versions of these functions are in libc, so use them. (I had to bump libc to 0.2.161 to pull in the definition of `POLLRDHUP` on FreeBSD.)

This is an intermediate commit that should hopefully be uncontroversial. The full test suite still doesn't pass on illumos yet, but I'm still working on it (in my spare time).