### PR TITLE
Add support for illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["rc"] }
 uuid = { version = "1", features = ["v4"] }
 
-[target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd", target_os = "illumos"))'.dependencies]
 mio = { version = "1.0", features = ["os-ext"] }
 tempfile = "3.4"
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -9,12 +9,22 @@
 
 #[cfg(all(
     not(feature = "force-inprocess"),
-    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
+    any(
+        target_os = "linux",
+        target_os = "openbsd",
+        target_os = "freebsd",
+        target_os = "illumos",
+    )
 ))]
 mod unix;
 #[cfg(all(
     not(feature = "force-inprocess"),
-    any(target_os = "linux", target_os = "openbsd", target_os = "freebsd")
+    any(
+        target_os = "linux",
+        target_os = "openbsd",
+        target_os = "freebsd",
+        target_os = "illumos",
+    )
 ))]
 mod os {
     pub use super::unix::*;


### PR DESCRIPTION
With this commit, ipc-channel works and the full test suite passes on illumos. I've also added a small amount of debug logging that was invaluable to me while porting over ipc-channel to illumos.

I'm also happy to set up cross-compile CI, and if there's interest then I could chat with folks at Oxide about providing resources for runtime CI as well.