### PR TITLE
in recvmsg, pass in MSG_CMSG_CLOEXEC on illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ fnv = "1.0.3"
 futures = { version = "0.3", optional = true }
 futures-test = { version = "0.3", optional = true }
 lazy_static = "1"
-libc = "0.2.161"
+libc = "0.2.162"
 rand = "0.8"
 serde = { version = "1.0", features = ["rc"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -32,7 +32,7 @@ use std::hash::BuildHasherDefault;
 use std::io;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::{Deref, DerefMut, RangeFrom};
+use std::ops::{Deref, RangeFrom};
 use std::os::fd::RawFd;
 use std::ptr;
 use std::slice;
@@ -54,9 +54,9 @@ const SOCK_FLAGS: c_int = libc::SOCK_CLOEXEC;
 #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
 const SOCK_FLAGS: c_int = 0;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "illumos"))]
 const RECVMSG_FLAGS: c_int = libc::MSG_CMSG_CLOEXEC;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "illumos")))]
 const RECVMSG_FLAGS: c_int = 0;
 
 #[cfg(target_env = "gnu")]


### PR DESCRIPTION
Support for MSG_CMSG_CLOEXEC was added to illumos in a [recent commit].  To match the behavior on Linux, pass in the flag on illumos (the definition was added in libc 0.2.162).

I've verified that the ipc-channel test suite still passes on an older illumos kernel which doesn't have support for it. This is okay because for returned fds, cloexec support is effectively best-effort.

[recent commit]: https://github.com/illumos/illumos-gate/commit/0250c53ad267726f2438e3c6556199a0bbf588a2