### PR TITLE
Deprecate old shared memory fd creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,6 @@ jobs:
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
           - { target: i686-pc-windows-msvc, os: windows-latest }
         features: ["", "force-inprocess", "async"]
-        include:
-          - features: ""
-            platform: { target: x86_64-pc-windows-msvc, os: windows-latest }
-          - features: ""
-            platform: { target: i686-pc-windows-msvc, os: windows-latest }
-          - features: "memfd"
-            platform: { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ harness = false
 [features]
 default = []
 force-inprocess = []
-memfd = []
 async = ["futures", "futures-test"]
 win32-trace = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,7 @@
     target_os = "android",
     target_os = "ios"
 ))]
-#[cfg(all(
-    feature = "memfd",
-    not(feature = "force-inprocess"),
-    target_os = "linux"
-))]
+#[cfg(all(not(feature = "force-inprocess"), target_os = "linux"))]
 #[cfg(feature = "async")]
 use futures;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,6 @@
 //! The `inprocess` backend is a dummy back-end, that behaves like the real ones,
 //! but doesn't actually work between processes.
 //!
-//! ## `memfd`
-//!
-//! Use [memfd_create] to back [OsIpcSharedMemory] on Linux. [memfd_create] was
-//! introduced in kernel version 3.17. __WARNING:__ Enabling this feature with kernel
-//! version less than 3.17 will cause panics on any use of [IpcSharedMemory].
-//!
 //! ## `unstable`
 //!
 //! [IpcReceiver]: ipc/struct.IpcReceiver.html
@@ -32,7 +26,6 @@
 //! [IpcReceiverSet]: ipc/struct.IpcReceiverSet.html
 //! [IpcSharedMemory]: ipc/struct.IpcSharedMemory.html
 //! [OsIpcSharedMemory]: platform/struct.OsIpcSharedMemory.html
-//! [memfd_create]: http://man7.org/linux/man-pages/man2/memfd_create.2.html
 
 #[cfg(any(
     feature = "force-inprocess",


### PR DESCRIPTION
During the attempt to fix `gaol <> ipc-channel` incompatibilities, I was trying to fix the errors first. the `memfd_create` is fixable on gaol side, but I was not able to fix the `shm_open`.

I cannot really point out the issue. I suspect some tricky bitflip playing around the usernamespace and permissions, but I have no evidence tbh.

---

Anyhow, `memfd_create` is part of the linux kernel from 2014, and also part of FreeBSD from 2021.
I don't see strong reason to keep the older `shm_open` method.

according to [GNU libc manual](https://www.gnu.org/software/libc/manual/html_node/Memory_002dmapped-I_002fO.html#index-shm_005fopen):
- `shm_open`: MT-Safe locale | AS-Unsafe init heap lock | AC-Unsafe lock mem fd
- `memfd_create`: MT-Safe | AS-Safe | AC-Safe fd
