### PR TITLE
Test cloning sender after receiver dropped

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -689,6 +689,13 @@ fn test_reentrant() {
 }
 
 #[test]
+fn clone_sender_after_receiver_dropped() {
+    let (tx, rx) = ipc::channel::<u32>().unwrap();
+    drop(rx);
+    let _tx2 = tx.clone();
+}
+
+#[test]
 fn transfer_closed_sender() {
     let (main_tx, main_rx) = ipc::channel().unwrap();
     let (transfer_tx, _) = ipc::channel::<()>().unwrap();


### PR DESCRIPTION
The test transfer_closed_sender will fail if issue 13 regresses, but this explicit test documents the expected behaviour better.

Ref: https://github.com/servo/ipc-channel/issues/13