### PR TITLE
Deprecate connect() in favour of IpcConnector

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -359,7 +359,7 @@ where
     ///
     /// [IpcSender]: struct.IpcSender.html
     /// [IpcOneShotServer]: struct.IpcOneShotServer.html
-    #[deprecated(since="0.20.0", note="please use `new_with_connector` instead")]
+    #[deprecated(since = "0.20.0", note = "please use `new_with_connector` instead")]
     pub fn connect(name: String) -> Result<IpcSender<T>, io::Error> {
         Ok(IpcSender {
             os_sender: OsIpcSender::connect(name)?,
@@ -876,7 +876,7 @@ impl<T> IpcOneShotServer<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    #[deprecated(since="0.20.0", note="please use `new_with_connector` instead")]
+    #[deprecated(since = "0.20.0", note = "please use `new_with_connector` instead")]
     pub fn new() -> Result<(IpcOneShotServer<T>, String), io::Error> {
         let (os_server, name) = OsIpcOneShotServer::new()?;
         Ok((
@@ -900,7 +900,6 @@ where
                 phantom: PhantomData,
             },
         ))
-
     }
 
     pub fn accept(self) -> Result<(IpcReceiver<T>, T), bincode::Error> {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -353,6 +353,10 @@ where
 {
     /// Create an [IpcSender] connected to a previously defined [IpcOneShotServer].
     ///
+    /// This function should not be called more than once per [IpcOneShotServer],
+    /// otherwise the behaviour is unpredictable.
+    /// See [issue 378](https://github.com/servo/ipc-channel/issues/378) for details.
+    ///
     /// [IpcSender]: struct.IpcSender.html
     /// [IpcOneShotServer]: struct.IpcOneShotServer.html
     pub fn connect(name: String) -> Result<IpcSender<T>, io::Error> {


### PR DESCRIPTION
_This draft pull request prototypes a replacement for connect() with its unpredictable behaviour when called more than once per one-shot server._

Introduce IpcConnector as a means of forcing at most one connect request to a one-shot server.

For a smooth upgrade experience, deprecate new() and connect() in favour of new_with_connector() and its connect() method, respectively.

new() will be deleted in a future release at which point new_with_connector() could be renamed new().

Note that new_with_connector() does not support all the usecases of new(), but should be sufficient for Servo. In particular, it does not support launching a process passing the name of a one-shot server to which the process may then connect.

Ref: https://github.com/servo/ipc-channel/issues/378