### PR TITLE
Deprecate one-shot server

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -359,7 +359,7 @@ where
     ///
     /// [IpcSender]: struct.IpcSender.html
     /// [IpcOneShotServer]: struct.IpcOneShotServer.html
-    #[deprecated(since="0.20.0", note="please use `new_with_sender` instead")]
+    #[deprecated(since="0.20.0", note="please use `ipc::channel` instead")]
     pub fn connect(name: String) -> Result<IpcSender<T>, io::Error> {
         Ok(IpcSender {
             os_sender: OsIpcSender::connect(name)?,
@@ -867,6 +867,7 @@ impl Serialize for OpaqueIpcReceiver {
 /// assert_eq!(data, vec![0x48, 0x65, 0x6b, 0x6b, 0x6f, 0x00]);
 /// ```
 /// [IpcSender]: struct.IpcSender.html
+#[deprecated(since="0.20.0", note="please use `ipc::channel` instead")]
 pub struct IpcOneShotServer<T> {
     os_server: OsIpcOneShotServer,
     phantom: PhantomData<T>,
@@ -876,7 +877,7 @@ impl<T> IpcOneShotServer<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    #[deprecated(since="0.20.0", note="please use `new_with_sender` instead")]
+    #[deprecated(since="0.20.0", note="please use `ipc::channel` instead")]
     pub fn new() -> Result<(IpcOneShotServer<T>, String), io::Error> {
         let (os_server, name) = OsIpcOneShotServer::new()?;
         Ok((
@@ -885,20 +886,6 @@ where
                 phantom: PhantomData,
             },
             name,
-        ))
-    }
-
-    pub fn new_with_sender() -> Result<(IpcOneShotServer<T>, IpcSender<T>), io::Error> {
-        let (os_server, name) = OsIpcOneShotServer::new()?;
-        Ok((
-            IpcOneShotServer {
-                os_server,
-                phantom: PhantomData,
-            },
-            IpcSender {
-                os_sender: OsIpcSender::connect(name)?,
-                phantom: PhantomData,
-            },
         ))
     }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -359,7 +359,7 @@ where
     ///
     /// [IpcSender]: struct.IpcSender.html
     /// [IpcOneShotServer]: struct.IpcOneShotServer.html
-    #[deprecated(since="0.20.0", note="please use `new_with_connector` instead")]
+    #[deprecated(since="0.20.0", note="please use `new_with_sender` instead")]
     pub fn connect(name: String) -> Result<IpcSender<T>, io::Error> {
         Ok(IpcSender {
             os_sender: OsIpcSender::connect(name)?,
@@ -876,7 +876,7 @@ impl<T> IpcOneShotServer<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    #[deprecated(since="0.20.0", note="please use `new_with_connector` instead")]
+    #[deprecated(since="0.20.0", note="please use `new_with_sender` instead")]
     pub fn new() -> Result<(IpcOneShotServer<T>, String), io::Error> {
         let (os_server, name) = OsIpcOneShotServer::new()?;
         Ok((
@@ -888,19 +888,18 @@ where
         ))
     }
 
-    pub fn new_with_connector() -> Result<(IpcOneShotServer<T>, IpcConnector<T>), io::Error> {
+    pub fn new_with_sender() -> Result<(IpcOneShotServer<T>, IpcSender<T>), io::Error> {
         let (os_server, name) = OsIpcOneShotServer::new()?;
         Ok((
             IpcOneShotServer {
                 os_server,
                 phantom: PhantomData,
             },
-            IpcConnector {
-                name,
+            IpcSender {
+                os_sender: OsIpcSender::connect(name)?,
                 phantom: PhantomData,
             },
         ))
-
     }
 
     pub fn accept(self) -> Result<(IpcReceiver<T>, T), bincode::Error> {
@@ -912,25 +911,6 @@ where
             },
             ipc_message.to()?,
         ))
-    }
-}
-
-/// A means of connecting to an [IpcOneShotServer].
-/// [IpcOneShotServer]: struct.IpcOneShotServer.html
-pub struct IpcConnector<T> {
-    name: String,
-    phantom: PhantomData<T>,
-}
-
-impl<T> IpcConnector<T>
-where
-    T: for<'de> Deserialize<'de> + Serialize,
-{
-    pub fn connect(self) -> Result<IpcSender<T>, io::Error> {
-        Ok(IpcSender {
-            os_sender: OsIpcSender::connect(self.name)?,
-            phantom: PhantomData,
-        })
     }
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -353,6 +353,10 @@ where
 {
     /// Create an [IpcSender] connected to a previously defined [IpcOneShotServer].
     ///
+    /// This function should not be called more than once per [IpcOneShotServer],
+    /// otherwise the behaviour is unpredictable.
+    /// See [issue 378](https://github.com/servo/ipc-channel/issues/378) for details.
+    ///
     /// [IpcSender]: struct.IpcSender.html
     /// [IpcOneShotServer]: struct.IpcOneShotServer.html
     pub fn connect(name: String) -> Result<IpcSender<T>, io::Error> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -274,15 +274,13 @@ fn cross_process_embedded_senders_fork() {
 #[test]
 fn cross_process_embedded_senders_fork_with_connector() {
     let person = ("Patrick Walton".to_owned(), 29);
-    let (server0, server0_connector) = IpcOneShotServer::new_with_connector().unwrap();
-    let (server2, server2_connector) = IpcOneShotServer::new_with_connector().unwrap();
+    let (server0, tx0) = IpcOneShotServer::new_with_sender().unwrap();
+    let (server2, tx2) = IpcOneShotServer::new_with_sender().unwrap();
     let child_pid = unsafe {
         fork(|| {
             let (tx1, rx1): (IpcSender<Person>, IpcReceiver<Person>) = ipc::channel().unwrap();
-            let tx0 = server0_connector.connect().unwrap();
             tx0.send(tx1).unwrap();
             rx1.recv().unwrap();
-            let tx2: IpcSender<Person> = server2_connector.connect().unwrap();
             tx2.send(person.clone()).unwrap();
         })
     };


### PR DESCRIPTION
_This draft pull request prototypes a drastic replacement for connect() with its unpredictable behaviour when called more than once per one-shot server._

ipc::channel seems sufficient for Servo's needs.

