### PR TITLE
optimize and upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,27 +26,30 @@ harness = false
 [features]
 default = []
 force-inprocess = []
-async = ["futures", "futures-test"]
+async = ["dep:futures-core", "dep:futures-channel"]
 win32-trace = []
 
 [dependencies]
 bincode = "1"
 crossbeam-channel = "0.5"
 fnv = "1.0.3"
-futures = { version = "0.3", optional = true }
-futures-test = { version = "0.3", optional = true }
+futures-channel = { version = "0.3.31", optional = true }
+futures-core = { version = "0.3.31", optional = true }
 lazy_static = "1"
 libc = "0.2.162"
-rand = "0.8"
 serde = { version = "1.0", features = ["rc"] }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd", target_os = "illumos"))'.dependencies]
-mio = { version = "1.0", features = ["os-ext"] }
+mio = { version = "1.0", default-features = false, features = ["os-ext"] }
 tempfile = "3.4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+rand = "0.9"
 
 [dev-dependencies]
 crossbeam-utils = "0.8"
+futures-test = "0.3"
 static_assertions = "1.1.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -10,12 +10,12 @@
 use crate::ipc::{
     self, IpcMessage, IpcReceiver, IpcReceiverSet, IpcSelectionResult, IpcSender, OpaqueIpcReceiver,
 };
-use futures::channel::mpsc::UnboundedReceiver;
-use futures::channel::mpsc::UnboundedSender;
-use futures::stream::FusedStream;
-use futures::task::Context;
-use futures::task::Poll;
-use futures::Stream;
+use futures_channel::mpsc::UnboundedReceiver;
+use futures_channel::mpsc::UnboundedSender;
+use futures_core::stream::FusedStream;
+use futures_core::task::Context;
+use futures_core::task::Poll;
+use futures_core::Stream;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use serde::Serialize;
@@ -44,7 +44,7 @@ struct Router {
 // so we only end up with one routing thread per process.
 lazy_static! {
     static ref ROUTER: Router = {
-        let (send, mut recv) = futures::channel::mpsc::unbounded();
+        let (send, mut recv) = futures_channel::mpsc::unbounded();
         let (waker, wakee) = ipc::channel().expect("Failed to create IPC channel");
         thread::spawn(move || {
             let mut receivers = IpcReceiverSet::new().expect("Failed to create receiver set");
@@ -86,7 +86,7 @@ where
     /// Convert this IPC receiver into a stream.
     pub fn to_stream(self) -> IpcStream<T> {
         let opaque = self.to_opaque();
-        let (send, recv) = futures::channel::mpsc::unbounded();
+        let (send, recv) = futures_channel::mpsc::unbounded();
         let _ = ROUTER.add_route.unbounded_send((opaque, send));
         if let Ok(waker) = ROUTER.wakeup.lock() {
             let _ = waker.send(());

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -267,7 +267,7 @@ impl OsIpcReceiver {
             let mut os_result;
             let mut name;
             loop {
-                name = format!("{}{}", BOOTSTRAP_PREFIX, rand::thread_rng().gen::<i64>());
+                name = format!("{}{}", BOOTSTRAP_PREFIX, rand::rng().random::<i64>());
                 let c_name = CString::new(name.clone()).unwrap();
                 os_result = bootstrap_register2(bootstrap_port, c_name.as_ptr(), right, 0);
                 if os_result == BOOTSTRAP_NAME_IN_USE {

--- a/src/test.rs
+++ b/src/test.rs
@@ -706,9 +706,9 @@ fn transfer_closed_sender() {
 #[cfg(feature = "async")]
 #[test]
 fn test_receiver_stream() {
-    use futures::task::Context;
-    use futures::task::Poll;
-    use futures::Stream;
+    use futures_core::task::Context;
+    use futures_core::task::Poll;
+    use futures_core::Stream;
     use std::pin::Pin;
     let (tx, rx) = ipc::channel().unwrap();
     let (waker, count) = futures_test::task::new_count_waker();


### PR DESCRIPTION
- futures-test is moved to dev dependencies
- depend on futures-core and futures-channel instead of all of futures
- move (and upgrade) rand to mac-only dependencies