### PR TITLE
Clarify behaviour of embedded IpcSenders and IpcReceivers

### DIFF
--- a/src/bin/spawn_receiver_sender_client.rs
+++ b/src/bin/spawn_receiver_sender_client.rs
@@ -1,0 +1,27 @@
+// Copyright 2025 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use std::{env, process};
+
+/// Test executable which connects to the one-shot server with name
+/// passed in as an argument and then sends a receiver to the server
+/// and then a test message to the receiver.
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let token = args.get(1).expect("missing argument");
+
+    let (sub_tx, sub_rx) = ipc::channel().unwrap();
+
+    let tx: IpcSender<IpcReceiver<String>> = IpcSender::connect(token.to_string()).expect("connect failed");
+    tx.send(sub_rx).expect("send failed");
+    sub_tx.send("test message".to_string()).expect("send failed");
+
+    process::exit(0);
+}

--- a/src/bin/spawn_used_receiver_sender_client.rs
+++ b/src/bin/spawn_used_receiver_sender_client.rs
@@ -1,0 +1,31 @@
+// Copyright 2025 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use std::{env, process};
+
+/// Test executable which connects to the one-shot server with name
+/// passed in as an argument and then sends a receiver which it has
+/// already used to the server and then sends a test message to the
+/// receiver.
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let token = args.get(1).expect("missing argument");
+
+    let (sub_tx, sub_rx) = ipc::channel().unwrap();
+    sub_tx.send("test message".to_string()).expect("send failed");
+    let msg = sub_rx.recv().unwrap();
+    assert_eq!("test message", msg);
+
+    let tx: IpcSender<IpcReceiver<String>> = IpcSender::connect(token.to_string()).expect("connect failed");
+    tx.send(sub_rx).expect("send failed");
+    sub_tx.send("test message".to_string()).expect("send failed");
+
+    process::exit(0);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -164,6 +164,26 @@ fn embedded_receivers() {
 }
 
 #[test]
+fn embedded_receivers_used_before_and_after_transmission() {
+    let person = ("Patrick Walton".to_owned(), 29);
+    let (sub_tx, sub_rx) = ipc::channel().unwrap();
+
+    sub_tx.send(person.clone()).unwrap();
+    let received_person1 = sub_rx.recv().unwrap();
+    assert_eq!(received_person1, person);
+
+    let person_and_receiver = (person.clone(), sub_rx);
+    let (super_tx, super_rx) = ipc::channel().unwrap();
+    super_tx.send(person_and_receiver).unwrap();
+    let received_person_and_receiver = super_rx.recv().unwrap();
+    assert_eq!(received_person_and_receiver.0, person);
+    
+    sub_tx.send(person.clone()).unwrap();
+    let received_person2 = received_person_and_receiver.1.recv().unwrap();
+    assert_eq!(received_person2, person);
+}
+
+#[test]
 fn select() {
     let (tx0, rx0) = ipc::channel().unwrap();
     let (tx1, rx1) = ipc::channel().unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -254,6 +254,8 @@ fn cross_process_embedded_senders_spawn() {
         unsafe {
             libc::exit(0);
         }
+    } else {
+        assert!(false, "dead testcase");
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -236,29 +236,6 @@ fn select() {
     }
 }
 
-#[cfg(not(any(feature = "force-inprocess", target_os = "android", target_os = "ios")))]
-#[test]
-fn cross_process_embedded_senders_spawn() {
-    let person = ("Patrick Walton".to_owned(), 29);
-
-    let server0_name = get_channel_name_arg("server0");
-    let server2_name = get_channel_name_arg("server2");
-    if let (Some(server0_name), Some(server2_name)) = (server0_name, server2_name) {
-        let (tx1, rx1): (IpcSender<Person>, IpcReceiver<Person>) = ipc::channel().unwrap();
-        let tx0 = IpcSender::connect(server0_name).unwrap();
-        tx0.send(tx1).unwrap();
-        rx1.recv().unwrap();
-        let tx2: IpcSender<Person> = IpcSender::connect(server2_name).unwrap();
-        tx2.send(person.clone()).unwrap();
-
-        unsafe {
-            libc::exit(0);
-        }
-    } else {
-        assert!(false, "dead testcase");
-    }
-}
-
 #[cfg(not(any(
     feature = "force-inprocess",
     target_os = "windows",


### PR DESCRIPTION
I've been trying to understand the behaviour of embedded IpcSenders and (especially) IpcReceivers. I offer this PR as clarification of the current behaviour. Whether the current behaviour is intended or not, I hope to learn via this PR (both from review and Windows CI, as I don't have access to a Windows system).

The PR deletes a testcase which doesn't seem to achieve anything useful, although I haven't checked the git history to see if it used to achieve anything useful.