### PR TITLE
Propagate deserialization errors for IpcSharedMemory

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -581,7 +581,7 @@ impl<'de> Deserialize<'de> for IpcSharedMemory {
             |os_ipc_shared_memory_regions_for_deserialization| {
                 let mut regions =  os_ipc_shared_memory_regions_for_deserialization.borrow_mut();
                 let Some(region) = regions.get_mut(index) else {
-                    return Err(format!("Cannot consume shared memory region {index}, there are only {} regions available", regions.len()));
+                    return Err(format!("Cannot consume shared memory region at index {index}, there are only {} regions available", regions.len()));
                 };
 
                 region.take().ok_or_else(|| format!("Shared memory region {index} has already been consumed"))

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -13,7 +13,7 @@ use crate::platform::{
 };
 
 use bincode;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::cell::RefCell;
 use std::cmp::min;
 use std::error::Error as StdError;
@@ -579,13 +579,15 @@ impl<'de> Deserialize<'de> for IpcSharedMemory {
 
         let os_shared_memory = OS_IPC_SHARED_MEMORY_REGIONS_FOR_DESERIALIZATION.with(
             |os_ipc_shared_memory_regions_for_deserialization| {
-                // FIXME(pcwalton): This could panic if the data was corrupt and the index was out
-                // of bounds. We should return an `Err` result instead.
-                os_ipc_shared_memory_regions_for_deserialization.borrow_mut()[index]
-                    .take()
-                    .unwrap()
+                let mut regions =  os_ipc_shared_memory_regions_for_deserialization.borrow_mut();
+                let Some(region) = regions.get_mut(index) else {
+                    return Err(format!("Cannot consume shared memory region {index}, there are only {} regions available", regions.len()));
+                };
+
+                region.take().ok_or_else(|| format!("Shared memory region {index} has already been consumed"))
             },
-        );
+        ).map_err(D::Error::custom)?;
+
         Ok(IpcSharedMemory {
             os_shared_memory: Some(os_shared_memory),
         })

--- a/src/router.rs
+++ b/src/router.rs
@@ -47,7 +47,10 @@ impl RouterProxy {
         // Router proxy takes both sending ends.
         let (msg_sender, msg_receiver) = crossbeam_channel::unbounded();
         let (wakeup_sender, wakeup_receiver) = ipc::channel().unwrap();
-        thread::spawn(move || Router::new(msg_receiver, wakeup_receiver).run());
+        thread::Builder::new()
+            .name("router-proxy".to_string())
+            .spawn(move || Router::new(msg_receiver, wakeup_receiver).run())
+            .expect("Failed to spawn router proxy thread");
         RouterProxy {
             comm: Mutex::new(RouterProxyComm {
                 msg_sender,


### PR DESCRIPTION
This makes `IpcSharedMemory::deserialize` return an error if the deserialized data references an shared memory region region that does not exist.

Part of https://github.com/servo/servo/issues/36792. This doesn't fix the actual issue, but gives users of `ipc-channel` the opportunity to handle the error gracefully. Servo is technically at fault for panicking now, because serialized data being corrupted is not unrealistic.