### PR TITLE
Publish 0.20.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.20.0"
+version = "0.20.1"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Includes changes from #397 and #400, neither of which are public API changes.