### PR TITLE
Skip router_flood test for the debug profile

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -324,6 +324,7 @@ fn router_simple_global() {
     ROUTER.shutdown();
 }
 
+#[cfg(not(debug_assertions))] // skip the test for the debug profile
 #[test]
 fn router_flood() {
     let router = RouterProxy::new();


### PR DESCRIPTION
The debug profile check was found in:

https://stackoverflow.com/questions/39204908/how-to-check-release-debug-builds-using-cfg-in-rust

Fixes: https://github.com/servo/ipc-channel/issues/402