### PR TITLE
chore: Fix clippy warning on `force-inprocess` feature

### DIFF
--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -359,6 +359,10 @@ impl Deref for OsIpcSharedMemory {
 
 impl OsIpcSharedMemory {
     /// # Safety
+    ///
+    /// This is safe if there is only one reader/writer on the data.
+    /// User can achieve this by not cloning [`IpcSharedMemory`]
+    /// and serializing/deserializing only once.
     #[inline]
     pub unsafe fn deref_mut(&mut self) -> &mut [u8] {
         if self.ptr.is_null() {


### PR DESCRIPTION
This will fix the linting error when running clippy on `force-inprocess` feature 