### PR TITLE
Support one-shot router handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc-channel"
-version = "0.20.2"
+version = "0.21.0"
 description = "A multiprocess drop-in replacement for Rust channels"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,11 +62,7 @@ impl RouterProxy {
 
     /// Add a new (receiver, callback) pair to the router, and send a wakeup message
     /// to the router.
-    ///
-    /// Consider using [add_typed_route](Self::add_typed_route) instead, which prevents
-    /// mismatches between the receiver and callback types.
-    #[deprecated(since = "0.19.0", note = "please use 'add_typed_route' instead")]
-    pub fn add_route(&self, receiver: OpaqueIpcReceiver, callback: RouterHandler) {
+    fn add_route(&self, receiver: OpaqueIpcReceiver, callback: RouterHandler) {
         let comm = self.comm.lock().unwrap();
 
         if comm.shutdown {
@@ -81,9 +77,6 @@ impl RouterProxy {
 
     /// Add a new `(receiver, callback)` pair to the router, and send a wakeup message
     /// to the router.
-    ///
-    /// Unlike [add_route](Self::add_route) this method is strongly typed and guarantees
-    /// that the `receiver` and the `callback` use the same message type.
     pub fn add_typed_route<T>(&self, receiver: IpcReceiver<T>, mut callback: TypedRouterHandler<T>)
     where
         T: Serialize + for<'de> Deserialize<'de> + 'static,
@@ -94,7 +87,6 @@ impl RouterProxy {
             callback(typed_message)
         };
 
-        #[allow(deprecated)]
         self.add_route(receiver.to_opaque(), Box::new(modified_callback));
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -274,11 +274,10 @@ fn router_simple_global() {
     tx.send(person.clone()).unwrap();
 
     let (callback_fired_sender, callback_fired_receiver) = crossbeam_channel::unbounded::<Person>();
-    #[allow(deprecated)]
-    ROUTER.add_route(
-        rx.to_opaque(),
+    ROUTER.add_typed_route(
+        rx,
         Box::new(move |person| {
-            callback_fired_sender.send(person.to().unwrap()).unwrap();
+            callback_fired_sender.send(person.unwrap()).unwrap();
         }),
     );
     let received_person = callback_fired_receiver.recv().unwrap();


### PR DESCRIPTION
Fixes #417. This allows more ergonomic router callbacks when the author knows the channels involved will only ever send one message.