### PR TITLE
Install target with rustup.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
       - name: rustfmt
         run: cargo fmt --check
 
+      - name: rustup target install
+        run: rustup target add '${{ matrix.platform.target }}'
+
       - name: clippy
         uses: servo/actions/cargo-annotation@main
         with:


### PR DESCRIPTION
This should fix the following x86 CI error:
```
Error: error[E0463]: can't find crate for `core`
  |
  = note: the `i686-pc-windows-msvc` target may not be installed
  = help: consider downloading the target with `rustup target add i686-pc-windows-msvc`
```