### PR TITLE
RFC: IpcSharedMemoryVec an appendable data structure which can be shared via a reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ fnv = "1.0.3"
 futures-channel = { version = "0.3.31", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 libc = "0.2.162"
-serde_core = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd", target_os = "illumos"))'.dependencies]

--- a/src/platform/inprocess/mod.rs
+++ b/src/platform/inprocess/mod.rs
@@ -153,9 +153,15 @@ impl OsIpcSender {
         data: &[u8],
         ports: Vec<OsIpcChannel>,
         shared_memory_regions: Vec<OsIpcSharedMemory>,
+        shared_memory_vecs: Vec<OsIpcSharedMemoryVec>,
     ) -> Result<(), ChannelError> {
         let os_ipc_channels = ports.into_iter().map(OsOpaqueIpcChannel::new).collect();
-        let ipc_message = IpcMessage::new(data.to_vec(), os_ipc_channels, shared_memory_regions);
+        let ipc_message = IpcMessage::new(
+            data.to_vec(),
+            os_ipc_channels,
+            shared_memory_regions,
+            shared_memory_vecs,
+        );
         self.sender
             .send(ChannelMessage(ipc_message))
             .map_err(|_| ChannelError::BrokenPipeError)

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -66,6 +66,7 @@ mod os {
 pub use self::os::{channel, OsOpaqueIpcChannel};
 pub use self::os::{OsIpcChannel, OsIpcOneShotServer, OsIpcReceiver, OsIpcReceiverSet};
 pub use self::os::{OsIpcSelectionResult, OsIpcSender, OsIpcSharedMemory};
+pub use self::os::{OsIpcSharedMemoryIndex, OsIpcSharedMemoryVec};
 
 #[cfg(test)]
 mod test;

--- a/src/platform/test.rs
+++ b/src/platform/test.rs
@@ -42,7 +42,7 @@ use crate::test::{get_channel_name_arg, spawn_server};
 fn simple() {
     let (tx, rx) = platform::channel().unwrap();
     let data: &[u8] = b"1234567";
-    tx.send(data, Vec::new(), Vec::new()).unwrap();
+    tx.send(data, Vec::new(), Vec::new(), Vec::new()).unwrap();
     let ipc_message = rx.recv().unwrap();
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
 }
@@ -53,12 +53,12 @@ fn sender_transfer() {
     let (sub_tx, sub_rx) = platform::channel().unwrap();
     let data: &[u8] = b"foo";
     super_tx
-        .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![])
+        .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![], vec![])
         .unwrap();
     let mut ipc_message = super_rx.recv().unwrap();
     assert_eq!(ipc_message.os_ipc_channels.len(), 1);
     let sub_tx = ipc_message.os_ipc_channels.pop().unwrap().to_sender();
-    sub_tx.send(data, vec![], vec![]).unwrap();
+    sub_tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message = sub_rx.recv().unwrap();
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
 }
@@ -69,12 +69,12 @@ fn receiver_transfer() {
     let (sub_tx, sub_rx) = platform::channel().unwrap();
     let data: &[u8] = b"foo";
     super_tx
-        .send(data, vec![OsIpcChannel::Receiver(sub_rx)], vec![])
+        .send(data, vec![OsIpcChannel::Receiver(sub_rx)], vec![], vec![])
         .unwrap();
     let mut ipc_message = super_rx.recv().unwrap();
     assert_eq!(ipc_message.os_ipc_channels.len(), 1);
     let sub_rx = ipc_message.os_ipc_channels.pop().unwrap().to_receiver();
-    sub_tx.send(data, vec![], vec![]).unwrap();
+    sub_tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message = sub_rx.recv().unwrap();
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
 }
@@ -90,18 +90,19 @@ fn multisender_transfer() {
             data,
             vec![OsIpcChannel::Sender(sub0_tx), OsIpcChannel::Sender(sub1_tx)],
             vec![],
+            vec![],
         )
         .unwrap();
     let mut ipc_message1 = super_rx.recv().unwrap();
     assert_eq!(ipc_message1.os_ipc_channels.len(), 2);
 
     let sub0_tx = ipc_message1.os_ipc_channels.remove(0).to_sender();
-    sub0_tx.send(data, vec![], vec![]).unwrap();
+    sub0_tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message2 = sub0_rx.recv().unwrap();
     assert_eq!(ipc_message2, IpcMessage::from_data(data.to_vec()));
 
     let sub1_tx = ipc_message1.os_ipc_channels.remove(0).to_sender();
-    sub1_tx.send(data, vec![], vec![]).unwrap();
+    sub1_tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message3 = sub1_rx.recv().unwrap();
     assert_eq!(ipc_message3, IpcMessage::from_data(data.to_vec()));
 }
@@ -113,7 +114,7 @@ fn medium_data() {
         .collect();
     let data: &[u8] = &data[..];
     let (tx, rx) = platform::channel().unwrap();
-    tx.send(data, vec![], vec![]).unwrap();
+    tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message = rx.recv().unwrap();
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
 }
@@ -127,12 +128,12 @@ fn medium_data_with_sender_transfer() {
     let (super_tx, super_rx) = platform::channel().unwrap();
     let (sub_tx, sub_rx) = platform::channel().unwrap();
     super_tx
-        .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![])
+        .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![], vec![])
         .unwrap();
     let mut ipc_message = super_rx.recv().unwrap();
     assert_eq!(ipc_message.os_ipc_channels.len(), 1);
     let sub_tx = ipc_message.os_ipc_channels.pop().unwrap().to_sender();
-    sub_tx.send(data, vec![], vec![]).unwrap();
+    sub_tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message = sub_rx.recv().unwrap();
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
 }
@@ -142,7 +143,7 @@ fn check_big_data(size: u32) {
     let thread = thread::spawn(move || {
         let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
         let data: &[u8] = &data[..];
-        tx.send(data, vec![], vec![]).unwrap();
+        tx.send(data, vec![], vec![], vec![]).unwrap();
     });
     let ipc_message = rx.recv().unwrap();
     let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
@@ -174,7 +175,7 @@ fn big_data_with_sender_transfer() {
         let data: Vec<u8> = (0..1024 * 1024).map(|i| (i % 251) as u8).collect();
         let data: &[u8] = &data[..];
         super_tx
-            .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![])
+            .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![], vec![])
             .unwrap();
     });
     let mut ipc_message = super_rx.recv().unwrap();
@@ -190,7 +191,7 @@ fn big_data_with_sender_transfer() {
         .collect();
     let data: &[u8] = &data[..];
     let sub_tx = ipc_message.os_ipc_channels[0].to_sender();
-    sub_tx.send(data, vec![], vec![]).unwrap();
+    sub_tx.send(data, vec![], vec![], vec![]).unwrap();
     let ipc_message = sub_rx.recv().unwrap();
     assert_eq!(ipc_message.data.len(), data.len());
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
@@ -205,7 +206,9 @@ fn with_n_fds(n: usize, size: usize) {
     let (super_tx, super_rx) = platform::channel().unwrap();
 
     let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
-    super_tx.send(&data[..], sender_fds, vec![]).unwrap();
+    super_tx
+        .send(&data[..], sender_fds, vec![], vec![])
+        .unwrap();
     let ipc_message = super_rx.recv().unwrap();
 
     assert_eq!(ipc_message.data.len(), data.len());
@@ -222,7 +225,7 @@ fn with_n_fds(n: usize, size: usize) {
         .zip(receivers.into_iter())
     {
         let sub_tx = sender_fd.to_sender();
-        sub_tx.send(&data, vec![], vec![]).unwrap();
+        sub_tx.send(&data, vec![], vec![], vec![]).unwrap();
         let ipc_message = sub_rx.recv().unwrap();
         assert_eq!(ipc_message.data.len(), data.len());
         assert_eq!(ipc_message, IpcMessage::from_data(data.clone()));
@@ -324,7 +327,7 @@ macro_rules! create_big_data_with_n_fds {
             let thread = thread::spawn(move || {
                 let data: Vec<u8> = (0..1024 * 1024).map(|i| (i % 251) as u8).collect();
                 let data: &[u8] = &data[..];
-                super_tx.send(data, sender_fds, vec![]).unwrap();
+                super_tx.send(data, sender_fds, vec![], vec![]).unwrap();
             });
             let ipc_message = super_rx.recv().unwrap();
             thread.join().unwrap();
@@ -346,7 +349,7 @@ macro_rules! create_big_data_with_n_fds {
                 .zip(receivers.into_iter())
             {
                 let sub_tx = sender_fd.to_sender();
-                sub_tx.send(data, vec![], vec![]).unwrap();
+                sub_tx.send(data, vec![], vec![], vec![]).unwrap();
                 let ipc_message = sub_rx.recv().unwrap();
                 assert_eq!(ipc_message.data.len(), data.len());
                 assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
@@ -375,7 +378,7 @@ fn concurrent_senders() {
             thread::spawn(move || {
                 let data: Vec<u8> = (0..1024 * 1024).map(|j| (j % 13) as u8 | i << 4).collect();
                 let data: &[u8] = &data[..];
-                tx.send(data, vec![], vec![]).unwrap();
+                tx.send(data, vec![], vec![], vec![]).unwrap();
             })
         })
         .collect();
@@ -410,7 +413,7 @@ fn receiver_set() {
     let rx1_id = rx_set.add(rx1).unwrap();
 
     let data: &[u8] = b"1234567";
-    tx0.send(data, vec![], vec![]).unwrap();
+    tx0.send(data, vec![], vec![], vec![]).unwrap();
     let (received_id, ipc_message) = rx_set
         .select()
         .unwrap()
@@ -421,7 +424,7 @@ fn receiver_set() {
     assert_eq!(received_id, rx0_id);
     assert_eq!(ipc_message.data, data);
 
-    tx1.send(data, vec![], vec![]).unwrap();
+    tx1.send(data, vec![], vec![], vec![]).unwrap();
     let (received_id, ipc_message) = rx_set
         .select()
         .unwrap()
@@ -432,8 +435,8 @@ fn receiver_set() {
     assert_eq!(received_id, rx1_id);
     assert_eq!(ipc_message.data, data);
 
-    tx0.send(data, vec![], vec![]).unwrap();
-    tx1.send(data, vec![], vec![]).unwrap();
+    tx0.send(data, vec![], vec![], vec![]).unwrap();
+    tx1.send(data, vec![], vec![], vec![]).unwrap();
     let (mut received0, mut received1) = (false, false);
     while !received0 || !received1 {
         for result in rx_set.select().unwrap().into_iter() {
@@ -467,7 +470,7 @@ fn receiver_set_eintr() {
             let rx_id = rx_set.add(rx0).unwrap();
             // Let the parent know we're ready
             let tx1 = OsIpcSender::connect(name).unwrap();
-            tx1.send(b" Ready! ", vec![OsIpcChannel::Sender(tx0)], vec![])
+            tx1.send(b" Ready! ", vec![OsIpcChannel::Sender(tx0)], vec![], vec![])
                 .unwrap();
             // Send the result of the select back to the parent
             let result = rx_set.select().unwrap();
@@ -476,7 +479,7 @@ fn receiver_set_eintr() {
             assert_eq!(rx_id, id);
             assert_eq!(b"Test".as_ref(), &*ipc_message.data);
             assert!(result_iter.next().is_none());
-            tx1.send(b"Success!", vec![], vec![]).unwrap();
+            tx1.send(b"Success!", vec![], vec![], vec![]).unwrap();
         })
     };
     // Wait until the child is ready
@@ -489,7 +492,7 @@ fn receiver_set_eintr() {
         kill(child_pid, SIGCONT);
     }
     // The interrupt shouldn't affect the following send
-    tx1.send(b"Test", vec![], vec![]).unwrap();
+    tx1.send(b"Test", vec![], vec![], vec![]).unwrap();
     let ipc_message = server.recv().unwrap();
     assert!(ipc_message.data == b"Success!");
     child_pid.wait();
@@ -502,7 +505,7 @@ fn receiver_set_empty() {
     let rx_id = rx_set.add(rx).unwrap();
 
     let data: &[u8] = b"";
-    tx.send(data, vec![], vec![]).unwrap();
+    tx.send(data, vec![], vec![], vec![]).unwrap();
     let (received_id, ipc_message) = rx_set
         .select()
         .unwrap()
@@ -562,8 +565,8 @@ fn receiver_set_medium_data() {
         .map(|offset| (offset % 127) as u8 | 0x80)
         .collect();
 
-    tx0.send(&data0, vec![], vec![]).unwrap();
-    tx1.send(&data1, vec![], vec![]).unwrap();
+    tx0.send(&data0, vec![], vec![], vec![]).unwrap();
+    tx1.send(&data1, vec![], vec![], vec![]).unwrap();
     let (mut received0, mut received1) = (false, false);
     while !received0 || !received1 {
         for result in rx_set.select().unwrap().into_iter() {
@@ -600,11 +603,11 @@ fn receiver_set_big_data() {
     let (reference_data0, reference_data1) = (data0.clone(), data1.clone());
 
     let thread0 = thread::spawn(move || {
-        tx0.send(&data0, vec![], vec![]).unwrap();
+        tx0.send(&data0, vec![], vec![], vec![]).unwrap();
         tx0 // Don't close just yet -- the receiver-side test code below doesn't expect that...
     });
     let thread1 = thread::spawn(move || {
-        tx1.send(&data1, vec![], vec![]).unwrap();
+        tx1.send(&data1, vec![], vec![], vec![]).unwrap();
         tx1
     });
 
@@ -656,7 +659,7 @@ fn receiver_set_concurrent() {
                     // The `macos` back-end won't receive exact size unless it's a multiple of 4...
                     // (See https://github.com/servo/ipc-channel/pull/79 etc. )
                     let msg_size = msg_size & !3;
-                    tx.send(&data[0..msg_size], vec![], vec![]).unwrap();
+                    tx.send(&data[0..msg_size], vec![], vec![], vec![]).unwrap();
                 }
             });
             (thread, (rx_id, (reference_data, chan_index, 0usize)))
@@ -696,7 +699,7 @@ fn server_accept_first() {
     thread::spawn(move || {
         thread::sleep(Duration::from_millis(30));
         let tx = OsIpcSender::connect(name).unwrap();
-        tx.send(data, vec![], vec![]).unwrap();
+        tx.send(data, vec![], vec![], vec![]).unwrap();
     });
 
     let (_, ipc_message) = server.accept().unwrap();
@@ -710,7 +713,7 @@ fn server_connect_first() {
 
     thread::spawn(move || {
         let tx = OsIpcSender::connect(name).unwrap();
-        tx.send(data, vec![], vec![]).unwrap();
+        tx.send(data, vec![], vec![], vec![]).unwrap();
     });
 
     thread::sleep(Duration::from_millis(30));
@@ -727,7 +730,7 @@ fn cross_process_spawn() {
     let channel_name = get_channel_name_arg("server");
     if let Some(channel_name) = channel_name {
         let tx = OsIpcSender::connect(channel_name).unwrap();
-        tx.send(data, vec![], vec![]).unwrap();
+        tx.send(data, vec![], vec![], vec![]).unwrap();
 
         unsafe {
             libc::exit(0);
@@ -756,7 +759,7 @@ fn cross_process_fork() {
     let child_pid = unsafe {
         fork(|| {
             let tx = OsIpcSender::connect(name).unwrap();
-            tx.send(data, vec![], vec![]).unwrap();
+            tx.send(data, vec![], vec![], vec![]).unwrap();
         })
     };
 
@@ -774,11 +777,11 @@ fn cross_process_sender_transfer_spawn() {
         let (sub_tx, sub_rx) = platform::channel().unwrap();
         let data: &[u8] = b"foo";
         super_tx
-            .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![])
+            .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![], vec![])
             .unwrap();
         sub_rx.recv().unwrap();
         let data: &[u8] = b"bar";
-        super_tx.send(data, vec![], vec![]).unwrap();
+        super_tx.send(data, vec![], vec![], vec![]).unwrap();
 
         unsafe {
             libc::exit(0);
@@ -792,7 +795,7 @@ fn cross_process_sender_transfer_spawn() {
     assert_eq!(ipc_message.os_ipc_channels.len(), 1);
     let sub_tx = ipc_message.os_ipc_channels[0].to_sender();
     let data: &[u8] = b"baz";
-    sub_tx.send(data, vec![], vec![]).unwrap();
+    sub_tx.send(data, vec![], vec![], vec![]).unwrap();
 
     let data: &[u8] = b"bar";
     let ipc_message = super_rx.recv().unwrap();
@@ -816,11 +819,11 @@ fn cross_process_sender_transfer_fork() {
             let (sub_tx, sub_rx) = platform::channel().unwrap();
             let data: &[u8] = b"foo";
             super_tx
-                .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![])
+                .send(data, vec![OsIpcChannel::Sender(sub_tx)], vec![], vec![])
                 .unwrap();
             sub_rx.recv().unwrap();
             let data: &[u8] = b"bar";
-            super_tx.send(data, vec![], vec![]).unwrap();
+            super_tx.send(data, vec![], vec![], vec![]).unwrap();
         })
     };
 
@@ -828,7 +831,7 @@ fn cross_process_sender_transfer_fork() {
     assert_eq!(ipc_message.os_ipc_channels.len(), 1);
     let sub_tx = ipc_message.os_ipc_channels[0].to_sender();
     let data: &[u8] = b"baz";
-    sub_tx.send(data, vec![], vec![]).unwrap();
+    sub_tx.send(data, vec![], vec![], vec![]).unwrap();
 
     let data: &[u8] = b"bar";
     let ipc_message = super_rx.recv().unwrap();
@@ -853,7 +856,7 @@ fn no_receiver_notification() {
     drop(receiver);
     let data: &[u8] = b"1234567";
     loop {
-        if let Err(err) = sender.send(data, vec![], vec![]) {
+        if let Err(err) = sender.send(data, vec![], vec![], vec![]) {
             // We don't have an actual method for distinguishing a "broken pipe" error --
             // but at least it's not supposed to signal the same condition as closing the sender.
             assert!(!err.channel_is_closed());
@@ -873,12 +876,12 @@ fn no_receiver_notification_pending() {
     let (sender, receiver) = platform::channel().unwrap();
     let data: &[u8] = b"1234567";
 
-    let result = sender.send(data, vec![], vec![]);
+    let result = sender.send(data, vec![], vec![], vec![]);
     assert!(result.is_ok());
 
     drop(receiver);
     loop {
-        if let Err(err) = sender.send(data, vec![], vec![]) {
+        if let Err(err) = sender.send(data, vec![], vec![], vec![]) {
             // We don't have an actual method for distinguishing a "broken pipe" error --
             // but at least it's not supposed to signal the same condition as closing the sender.
             assert!(!err.channel_is_closed());
@@ -901,7 +904,7 @@ fn no_receiver_notification_delayed() {
 
     let data: &[u8] = b"1234567";
     loop {
-        if let Err(err) = sender.send(data, vec![], vec![]) {
+        if let Err(err) = sender.send(data, vec![], vec![], vec![]) {
             // We don't have an actual method for distinguishing a "broken pipe" error --
             // but at least it's not supposed to signal the same condition as closing the sender.
             assert!(!err.channel_is_closed());
@@ -917,7 +920,7 @@ fn shared_memory() {
     let (tx, rx) = platform::channel().unwrap();
     let data: &[u8] = b"1234567";
     let shmem_data = OsIpcSharedMemory::from_byte(0xba, 1024 * 1024);
-    tx.send(data, vec![], vec![shmem_data]).unwrap();
+    tx.send(data, vec![], vec![shmem_data], vec![]).unwrap();
     let ipc_message = rx.recv().unwrap();
     assert_eq!(&ipc_message.data, data);
     assert!(&ipc_message.os_ipc_channels.is_empty());
@@ -942,7 +945,7 @@ fn try_recv() {
     let (tx, rx) = platform::channel().unwrap();
     assert!(rx.try_recv().is_err());
     let data: &[u8] = b"1234567";
-    tx.send(data, Vec::new(), Vec::new()).unwrap();
+    tx.send(data, Vec::new(), Vec::new(), Vec::new()).unwrap();
     let ipc_message = rx.try_recv().unwrap();
     assert_eq!(ipc_message, IpcMessage::from_data(data.to_vec()));
     assert!(rx.try_recv().is_err());
@@ -1003,7 +1006,7 @@ fn try_recv_large() {
     let thread = thread::spawn(move || {
         let data: Vec<u8> = (0..1024 * 1024).map(|i| (i % 251) as u8).collect();
         let data: &[u8] = &data[..];
-        tx.send(data, vec![], vec![]).unwrap();
+        tx.send(data, vec![], vec![], vec![]).unwrap();
     });
 
     let mut result;
@@ -1066,7 +1069,7 @@ fn try_recv_large_delayed() {
                 let data: Vec<u8> = (0..msg_size).map(|j| (j % 13) as u8 | i << 4).collect();
                 let data: &[u8] = &data[..];
                 delay(thread_delay);
-                tx.send(data, vec![], vec![]).unwrap();
+                tx.send(data, vec![], vec![], vec![]).unwrap();
             })
         })
         .collect();
@@ -1137,7 +1140,7 @@ fn cross_process_two_step_transfer_spawn() {
 
         // send the other process the tx side, so it can send us the channels
         super_tx
-            .send(&[], vec![OsIpcChannel::Sender(sub_tx)], vec![])
+            .send(&[], vec![OsIpcChannel::Sender(sub_tx)], vec![], vec![])
             .unwrap();
 
         // get two_rx from the other process
@@ -1155,7 +1158,9 @@ fn cross_process_two_step_transfer_spawn() {
         assert_eq!(&ipc_message.data[..], cookie);
 
         // finally, send a cookie back
-        super_tx.send(&ipc_message.data, vec![], vec![]).unwrap();
+        super_tx
+            .send(&ipc_message.data, vec![], vec![], vec![])
+            .unwrap();
 
         // terminate
         unsafe {
@@ -1166,13 +1171,13 @@ fn cross_process_two_step_transfer_spawn() {
     // create channel 1
     let (one_tx, one_rx) = platform::channel().unwrap();
     // put data in channel 1's pipe
-    one_tx.send(cookie, vec![], vec![]).unwrap();
+    one_tx.send(cookie, vec![], vec![], vec![]).unwrap();
 
     // create channel 2
     let (two_tx, two_rx) = platform::channel().unwrap();
     // put channel 1's rx end in channel 2's pipe
     two_tx
-        .send(&[], vec![OsIpcChannel::Receiver(one_rx)], vec![])
+        .send(&[], vec![OsIpcChannel::Receiver(one_rx)], vec![], vec![])
         .unwrap();
 
     // create a one-shot server, and spawn another process
@@ -1190,7 +1195,7 @@ fn cross_process_two_step_transfer_spawn() {
     // Send the outer payload channel, so the server can use it to
     // retrieve the inner payload and the cookie
     sub_tx
-        .send(&[], vec![OsIpcChannel::Receiver(two_rx)], vec![])
+        .send(&[], vec![OsIpcChannel::Receiver(two_rx)], vec![], vec![])
         .unwrap();
 
     // Then we wait for the cookie to make its way back to us

--- a/src/router.rs
+++ b/src/router.rs
@@ -18,7 +18,7 @@ use std::sync::{LazyLock, Mutex};
 use std::thread::{self, JoinHandle};
 
 use crossbeam_channel::{self, Receiver, Sender};
-use serde_core::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::ipc::{
     self, IpcMessage, IpcReceiver, IpcReceiverSet, IpcSelectionResult, IpcSender, OpaqueIpcReceiver,


### PR DESCRIPTION
This implements IpcSharedMemoryVec (similar to IpcSharedMemory).
This is an OS backed storage of a collection of bytes where we can add bytes to it.
We can access the bytes back with an IpcSharedMemoryIndex. Access is also facilitated with a IpcSharedMemoryVec::reader() method
which can be send over an ipc channel.

Currently this is an RFC because of two reasons:
- IpcSharedMemoryIndex should be serialize/deserialize so we can actually send it.
- Only the Unix implementation was implemented (and tested via tests and in servo context). Other implementations will follow.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
