### PR TITLE
Expose a way to manually set BOOTSTRAP_PREFIX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,5 @@ pub mod router;
 mod test;
 
 pub use bincode::{Error, ErrorKind};
+#[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
+pub use platform::set_bootstrap_prefix;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -36,6 +36,8 @@ mod macos;
 mod os {
     pub use super::macos::*;
 }
+#[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
+pub use macos::set_bootstrap_prefix;
 
 #[cfg(all(not(feature = "force-inprocess"), target_os = "windows"))]
 mod windows;


### PR DESCRIPTION
To be able to use this library in a sandboxed environment the prefix has to adhere to a specific format, [here's a link to a relevant SO discussion](https://stackoverflow.com/questions/9889186/cfmessageport-and-sandboxing)

I have no idea what would be the ideal approach to correctly expose the bootstrap prefix, in this pr it's basically slapped on in lib.rs, if this is a use case that you'd like to support let me know any changes needed to merge