### PR TITLE
Switch from fnv to rustc_hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ enable-slow-tests = []
 [dependencies]
 bincode = "1"
 crossbeam-channel = "0.5"
-fnv = "1.0.3"
 futures-channel = { version = "0.3.31", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 libc = "0.2.162"

--- a/src/platform/unix/mod.rs
+++ b/src/platform/unix/mod.rs
@@ -9,7 +9,6 @@
 
 use crate::ipc::{self, IpcMessage};
 use bincode;
-use rustc_hash::FxHasher;
 use libc::{
     self, cmsghdr, linger, CMSG_DATA, CMSG_LEN, CMSG_SPACE, MAP_FAILED, MAP_SHARED, PROT_READ,
     PROT_WRITE, SOCK_SEQPACKET, SOL_SOCKET,
@@ -20,6 +19,7 @@ use libc::{sa_family_t, setsockopt, size_t, sockaddr, sockaddr_un, socketpair, s
 use libc::{EAGAIN, EWOULDBLOCK};
 use mio::unix::SourceFd;
 use mio::{Events, Interest, Poll, Token};
+use rustc_hash::FxHasher;
 use std::cell::Cell;
 use std::cmp;
 use std::collections::HashMap;


### PR DESCRIPTION
Fnv hash is slower than rustc_hash especially for integer keys.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
