### PR TITLE
Notice callback drop timing in `add_route`

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -69,7 +69,7 @@ impl RouterProxy {
     /// Add a new (receiver, callback) pair to the router, and send a wakeup message
     /// to the router.
     ///
-    /// The `callback` is dropped when `receiver`'s channel disconnects
+    /// The `callback` is dropped when `receiver`'s channel disconnects.
     fn add_route(&self, receiver: OpaqueIpcReceiver, callback: RouterHandler) {
         let comm = self.comm.lock().unwrap();
 
@@ -86,7 +86,7 @@ impl RouterProxy {
     /// Add a new `(receiver, callback)` pair to the router, and send a wakeup message
     /// to the router.
     ///
-    /// The `callback` is dropped when `receiver`'s channel disconnects
+    /// The `callback` is dropped when `receiver`'s channel disconnects.
     pub fn add_typed_route<T>(
         &self,
         receiver: IpcReceiver<T>,


### PR DESCRIPTION
I have tried to look up if I could listen to channel disconnects on a `IpcReceiver` when I'm using the `ROUTER` and only found out that the `callback` is dropped on receiver's channel disconnects so I could move a drop guard in to the handler after looking into the actual implementation, so I thought it might be good to document this