### PR TITLE
Re-export SerDeError since it should be part of the API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,6 @@ pub mod router;
 #[cfg(test)]
 mod test;
 
-pub use error::{IpcError, TryRecvError, TrySelectError};
+pub use error::{IpcError, SerDeError, TryRecvError, TrySelectError};
 #[cfg(all(not(feature = "force-inprocess"), target_os = "macos"))]
 pub use platform::set_bootstrap_prefix;


### PR DESCRIPTION
Also display the detail of a SerDeError.

@Narfinger: please review.