### PR TITLE
windows: don't panic in OsIpcReceiverSet drop on IOCP error

### DIFF
--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1539,9 +1539,12 @@ impl Drop for OsIpcReceiverSet {
         // thus freeing the associated async data.
         self.readers.retain(|r| r.r#async.is_some());
         while !self.readers.is_empty() {
-            // We unwrap the outer result (can't deal with the IOCP call failing here),
-            // but don't care about the actual results of the completed read operations.
-            let _ = self.fetch_iocp_result(INFINITE).unwrap();
+            // Panicking out of Drop is worse than failing to drain the IOCP,
+            // so swallow the outer error and stop polling. Inner read results
+            // are intentionally discarded — the readers are about to be dropped.
+            if self.fetch_iocp_result(INFINITE).is_err() {
+                break;
+            }
         }
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -1541,7 +1541,7 @@ impl Drop for OsIpcReceiverSet {
         while !self.readers.is_empty() {
             // Panicking out of Drop is worse than failing to drain the IOCP,
             // so swallow the outer error and stop polling. Inner read results
-            // are intentionally discarded — the readers are about to be dropped.
+            // are intentionally discarded, the readers are about to be dropped.
             if self.fetch_iocp_result(INFINITE).is_err() {
                 break;
             }


### PR DESCRIPTION
Closes #427.

`fetch_iocp_result` is unwrapped inside the `Drop` impl for `OsIpcReceiverSet`, so an IOCP failure during teardown becomes a process panic, which is what the servo CI hit. Swallow the outer error and break out of the drain loop; the readers are about to be dropped anyway, and panicking out of `Drop` is worse than leaking a few read completions.